### PR TITLE
Move config generation into generic agent class

### DIFF
--- a/networking_ccloud/common/config/config_driver.py
+++ b/networking_ccloud/common/config/config_driver.py
@@ -71,6 +71,9 @@ class Switch(pydantic.BaseModel):
 
         return v
 
+    def get_rt(self, vni):
+        return f"{self.bgp_source_ip}:{vni}"
+
 
 # FIXME: put into consts
 roles = ["vpod", "stpod", "apod", "bgw"]

--- a/networking_ccloud/ml2/agent/common/messages.py
+++ b/networking_ccloud/ml2/agent/common/messages.py
@@ -18,6 +18,8 @@ from typing import List
 from oslo_log import log as logging
 import pydantic
 
+from networking_ccloud.ml2.agent.common.api import CCFabricSwitchAgentRPCClient
+
 LOG = logging.getLogger(__name__)
 
 
@@ -54,6 +56,9 @@ class BGP(pydantic.BaseModel):
     def add_vlan(self, rd, vlan, vni):
         if not self.vlans:
             self.vlans = []
+        for bv in self.vlans:
+            if bv.rd == rd and bv.vlan == vlan and bv.vni == vni:
+                return
         self.vlans.append(BGPVlan(rd=rd, vlan=vlan, vni=vni))
 
 
@@ -82,11 +87,15 @@ class IfaceConfig(pydantic.BaseModel):
     def add_trunk_vlan(self, vlan):
         if not self.trunk_vlans:
             self.trunk_vlans = []
-        self.trunk_vlans.append(vlan)
+        if vlan not in self.trunk_vlans:
+            self.trunk_vlans.append(vlan)
 
     def add_vlan_translation(self, inside, outside):
         if not self.vlan_translations:
             self.vlan_translations = []
+        for vt in self.vlan_translations:
+            if vt.inside == inside and vt.outside == outside:
+                return
         self.vlan_translations.append(VlanTranslation(inside=inside, outside=outside))
 
 
@@ -106,14 +115,111 @@ class SwitchConfigUpdate(pydantic.BaseModel):
     def add_vlan(self, vlan, name=None):
         if self.vlans is None:
             self.vlans = []
+        for v in self.vlans:
+            if v.vlan == vlan:
+                return
         self.vlans.append(Vlan(vlan=vlan, name=name))
 
     def add_vxlan_map(self, vni, vlan):
         if self.vxlan_maps is None:
             self.vxlan_maps = []
+        for vm in self.vxlan_maps:
+            if vm.vni == vni and vm.vlan == vlan:
+                return
         self.vxlan_maps.append(VXLANMapping(vni=vni, vlan=vlan))
 
     def add_iface(self, iface):
         if self.ifaces is None:
             self.ifaces = []
         self.ifaces.append(iface)
+
+        return iface
+
+    def get_or_create_iface(self, switchport):
+        if self.ifaces is None:
+            self.ifaces = []
+
+        for iface in self.ifaces:
+            if iface.name == switchport.name:
+                return iface
+
+        iface = IfaceConfig.from_switchport(switchport)
+        self.ifaces.append(iface)
+        return iface
+
+
+class SwitchConfigUpdateList:
+    def __init__(self, operation, drv_conf):
+        self.operation = operation
+        self.drv_conf = drv_conf
+        self.switch_config_updates = {}
+
+    def get_or_create_switch(self, switch_name):
+        if switch_name not in self.switch_config_updates:
+            self.switch_config_updates[switch_name] = SwitchConfigUpdate(switch_name=switch_name,
+                                                                         operation=self.operation)
+        return self.switch_config_updates[switch_name]
+
+    def add_binding_host_from_segment_to_config(self, binding_host, *args, **kwargs):
+        # find binding host
+        hg_config = self.drv_conf.get_hostgroup_by_host(binding_host)
+        if hg_config is None:
+            # FIXME: maybe don't use a value error here
+            raise ValueError(f"Could not find binding host {binding_host}")
+
+        return self.add_binding_host_to_config(hg_config, *args, **kwargs)
+
+    def add_binding_host_to_config(self, hg_config, network_id, seg_vni, seg_vlan, trunk_vlan=None,
+                                   keep_mapping=False, exclude_hosts=None):
+        """Add default (vpod) config to all required switches
+
+        Given a hostgroup config this method generates and adds config to this
+        config request. "Add" means that the config will be added, the overall
+        operation (add, remove, replace) is determined by self.operation.
+
+        Params:
+         * keep_mapping: determines if the vlan-vni mapping is kept on op=remove/replace
+         * exclude_hosts: hosts to exclude if a metagroup is being bound
+        """
+        add = self.operation == OperationEnum.add
+        for switch_name, switchports in hg_config.iter_switchports(self.drv_conf, exclude_hosts=exclude_hosts):
+            switch = self.drv_conf.get_switch_by_name(switch_name)
+            scu = self.get_or_create_switch(switch.name)
+
+            # add bgp stuff
+            if add or not keep_mapping:
+                if not scu.bgp:
+                    sg = self.drv_conf.get_switchgroup_by_switch_name(switch.name)
+                    scu.bgp = BGP(asn=sg.asn)
+                scu.bgp.add_vlan(switch.get_rt(seg_vni), seg_vlan, seg_vni)
+
+            # vlan-vxlan mapping
+            if add or not keep_mapping:
+                scu.add_vlan(seg_vlan, network_id)
+                scu.add_vxlan_map(seg_vni, seg_vlan)
+
+            # interface config
+            for sp in switchports:
+                iface = scu.get_or_create_iface(sp)
+                iface.add_trunk_vlan(seg_vlan)
+
+                if hg_config.direct_binding:
+                    if trunk_vlan:
+                        iface.add_vlan_translation(seg_vlan, trunk_vlan)
+                    else:
+                        iface.native_vlan = seg_vlan
+
+    def execute(self, context):
+        vendor_updates = {}
+        for scu in self.switch_config_updates.values():
+            vendor = self.drv_conf.get_switch_by_name(scu.switch_name).vendor
+            vendor_updates.setdefault(vendor, []).append(scu)
+
+        if not vendor_updates:
+            return False
+
+        for vendor, updates in vendor_updates.items():
+            rpc_client = CCFabricSwitchAgentRPCClient.get_for_vendor(vendor)
+            rpc_client.apply_config_update(context, updates)
+
+        return True

--- a/networking_ccloud/tests/unit/ml2/agent/common/test_messages.py
+++ b/networking_ccloud/tests/unit/ml2/agent/common/test_messages.py
@@ -1,0 +1,59 @@
+# Copyright 2021 SAP SE
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from networking_ccloud.ml2.agent.common import messages as agent_msg
+from networking_ccloud.tests import base
+
+
+class TestSwitchConfigUpdate(base.TestCase):
+    def setUp(self):
+        super().setUp()
+
+    def test_value_deduplication(self):
+        # Switch config update
+        scu = agent_msg.SwitchConfigUpdate(switch_name="seagull-sw1", operation=agent_msg.OperationEnum.add)
+        scu.add_vlan(23)
+        scu.add_vlan(23)
+        self.assertEqual(1, len(scu.vlans))
+        scu.add_vlan(42)
+        self.assertEqual(2, len(scu.vlans))
+
+        scu.add_vxlan_map(23, 42)
+        scu.add_vxlan_map(23, 42)
+        self.assertEqual(1, len(scu.vxlan_maps))
+        scu.add_vxlan_map(13, 137)
+        self.assertEqual(2, len(scu.vxlan_maps))
+
+        # iface
+        iface = agent_msg.IfaceConfig(name="e1/1/1/1")
+        iface.add_trunk_vlan(23)
+        iface.add_trunk_vlan(23)
+        self.assertEqual(1, len(iface.trunk_vlans))
+        iface.add_trunk_vlan(42)
+        self.assertEqual(2, len(iface.trunk_vlans))
+
+        iface.add_vlan_translation(23, 42)
+        iface.add_vlan_translation(23, 42)
+        self.assertEqual(1, len(iface.vlan_translations))
+        iface.add_vlan_translation(13, 37)
+        self.assertEqual(2, len(iface.vlan_translations))
+
+        # bgp
+        bgp = agent_msg.BGP(asn=65000)
+        bgp.add_vlan("foo", 23, 42)
+        bgp.add_vlan("foo", 23, 42)
+        self.assertEqual(1, len(bgp.vlans))
+        bgp.add_vlan("foo", 13, 37)
+        bgp.add_vlan("bar", 23, 42)
+        self.assertEqual(3, len(bgp.vlans))


### PR DESCRIPTION
Part of config generation was moved from the ml2 driver into the generic
switch config model. SwitchConfigUpdateList carries a list of
SwitchConfigUpdates and can also carry out the execution. This class
will get more methods in the future to configured bindings (i.e. for
BGWs / Transits). This will then be used by the API and the syncloop as
well.