### PR TITLE
Update Readme with doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-networking-ccloud
-###################
+# networking-ccloud
+This is `networking-ccloud`, the OpenStack Neutron ml2 driver for SAP Converged Cloud,
+running a VXLAN-BGP-EVPN fabric as the top-level network driver on Arista and NXOS devices.
+
+The documentation for this driver can currently be found [on GitHub pages](https://sapcc.github.io/networking-ccloud/).


### PR DESCRIPTION
Originally the plan was to directly include the readme in the docs, but
for now we're just keeping them separate. At some point we could use the
intro.rst as README.rst (if GitHub supports that nowadays) and don't
have to keep two copies, but... time will tell.