### PR TITLE
Replace vendor with platform

### DIFF
--- a/examples/cc-driver-config.yaml
+++ b/examples/cc-driver-config.yaml
@@ -15,13 +15,13 @@ switchgroups:
     name: qa-de-3-sw1111a-bb206
     password: bar
     user: foo
-    vendor: arista
+    platform: arista-eos
   - bgp_source_ip: 1.1.11.2
     host: 10.114.0.204
     name: qa-de-3-sw1111b-bb206
     password: bar
     user: foo
-    vendor: arista
+    platform: arista-eos
   name: bb206
   role: vpod
   vtep_ip: 1.1.11.0

--- a/networking_ccloud/common/constants.py
+++ b/networking_ccloud/common/constants.py
@@ -12,9 +12,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-VENDOR_ARISTA = "arista"
-VENDOR_NXOS = "nxos"
-VENDORS = [VENDOR_ARISTA, VENDOR_NXOS]
+PLATFORM_EOS = "arista-eos"
+PLATFORM_NXOS = "cisco-nx-os"
+PLATFORMS = [PLATFORM_EOS, PLATFORM_NXOS]
 
 HANDOVER_VLAN = 'vlan'
 HANDOVER_MODES = [HANDOVER_VLAN]
@@ -28,6 +28,6 @@ SWITCH_AGENT_ARISTA_TOPIC = 'cc-fabric-switch-agent-arista'
 SWITCH_AGENT_NXOS_TOPIC = 'cc-fabric-switch-agent-nxos'
 
 SWITCH_AGENT_TOPIC_MAP = {
-    'arista': SWITCH_AGENT_ARISTA_TOPIC,
-    'nxos': SWITCH_AGENT_NXOS_TOPIC,
+    PLATFORM_EOS: SWITCH_AGENT_ARISTA_TOPIC,
+    PLATFORM_NXOS: SWITCH_AGENT_NXOS_TOPIC,
 }

--- a/networking_ccloud/extensions/fabricoperations.py
+++ b/networking_ccloud/extensions/fabricoperations.py
@@ -132,10 +132,10 @@ class AgentCheckController(wsgi.Controller):
     def index(self, request, **kwargs):
         LOG.info("agent-check request %s kwargs %s", request, kwargs)
         resp = []
-        for vendor in self.drv_conf.get_vendors():
-            agent_resp = dict(vendor=vendor)
+        for platform in self.drv_conf.get_platforms():
+            agent_resp = dict(platform=platform)
             try:
-                rpc_client = CCFabricSwitchAgentRPCClient.get_for_vendor(vendor)
+                rpc_client = CCFabricSwitchAgentRPCClient.get_for_platform(platform)
                 agent_resp['response'] = rpc_client.ping_back_driver(request.context)
                 agent_resp['success'] = True
             except Exception as e:

--- a/networking_ccloud/ml2/agent/arista/switch.py
+++ b/networking_ccloud/ml2/agent/arista/switch.py
@@ -27,8 +27,8 @@ LOG = logging.getLogger(__name__)
 
 class AristaSwitch(SwitchBase):
     @classmethod
-    def get_vendor(self):
-        return cc_const.VENDOR_ARISTA
+    def get_platform(self):
+        return cc_const.PLATFORM_EOS
 
     def login(self):
         self._api = pyeapi.connect(

--- a/networking_ccloud/ml2/agent/common/agent.py
+++ b/networking_ccloud/ml2/agent/common/agent.py
@@ -58,7 +58,7 @@ class CCFabricSwitchAgent(manager.Manager, cc_agent_api.CCFabricSwitchAgentAPI):
     def _init_switches(self):
         """Init all switches the agent manages"""
         for switch_conf in self.drv_conf.get_switches():
-            if switch_conf.vendor != self.get_switch_class().get_vendor():
+            if switch_conf.platform != self.get_switch_class().get_platform():
                 continue
             switch = self.get_switch_class()(switch_conf)
             LOG.debug("Adding switch %s with user %s to switchpool", switch, switch.user)

--- a/networking_ccloud/ml2/agent/common/api.py
+++ b/networking_ccloud/ml2/agent/common/api.py
@@ -53,8 +53,8 @@ class CCFabricSwitchAgentRPCClient:
     """
 
     @classmethod
-    def get_for_vendor(cls, vendor):
-        return cls(cc_const.SWITCH_AGENT_TOPIC_MAP[vendor])
+    def get_for_platform(cls, platform):
+        return cls(cc_const.SWITCH_AGENT_TOPIC_MAP[platform])
 
     def __init__(self, topic):
         target = oslo_messaging.Target(topic=topic, version='1.0')

--- a/networking_ccloud/ml2/agent/common/messages.py
+++ b/networking_ccloud/ml2/agent/common/messages.py
@@ -210,16 +210,16 @@ class SwitchConfigUpdateList:
                         iface.native_vlan = seg_vlan
 
     def execute(self, context):
-        vendor_updates = {}
+        platform_updates = {}
         for scu in self.switch_config_updates.values():
-            vendor = self.drv_conf.get_switch_by_name(scu.switch_name).vendor
-            vendor_updates.setdefault(vendor, []).append(scu)
+            platform = self.drv_conf.get_switch_by_name(scu.switch_name).platform
+            platform_updates.setdefault(platform, []).append(scu)
 
-        if not vendor_updates:
+        if not platform_updates:
             return False
 
-        for vendor, updates in vendor_updates.items():
-            rpc_client = CCFabricSwitchAgentRPCClient.get_for_vendor(vendor)
+        for platform, updates in platform_updates.items():
+            rpc_client = CCFabricSwitchAgentRPCClient.get_for_platform(platform)
             rpc_client.apply_config_update(context, updates)
 
         return True

--- a/networking_ccloud/ml2/agent/common/switch.py
+++ b/networking_ccloud/ml2/agent/common/switch.py
@@ -32,7 +32,7 @@ class SwitchBase(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    def get_vendor(cls):
+    def get_platform(cls):
         pass
 
     @property

--- a/networking_ccloud/ml2/agent/nxos/switch.py
+++ b/networking_ccloud/ml2/agent/nxos/switch.py
@@ -25,8 +25,8 @@ LOG = logging.getLogger(__name__)
 
 class NXOSSwitch(SwitchBase):
     @classmethod
-    def get_vendor(self):
-        return cc_const.VENDOR_NXOS
+    def get_platform(self):
+        return cc_const.PLATFORM_NXOS
 
     def login(self):
         self._api = requests.Session()

--- a/networking_ccloud/tests/common/config_fixtures.py
+++ b/networking_ccloud/tests/common/config_fixtures.py
@@ -18,13 +18,13 @@ from networking_ccloud.common.config import config_driver
 DEFAULT_AZ = "qa-test-1a"
 
 
-def make_switch(name, vendor="test", **kwargs):
-    if vendor == "test":
-        # enable test vendor
-        config_driver.Switch._allow_test_vendor = True
+def make_switch(name, platform="test", **kwargs):
+    if platform == "test":
+        # enable test platform
+        config_driver.Switch._allow_test_platform = True
 
     switch_vars = dict(
-        name=name, vendor=vendor,
+        name=name, platform=platform,
         user="maunzuser", password="maunzpassword",
         host="1.1.1.1", bgp_source_ip="1.1.1.2",  # FIXME: derive IPs from somewhere
     )

--- a/networking_ccloud/tests/unit/common/test_driver_config.py
+++ b/networking_ccloud/tests/unit/common/test_driver_config.py
@@ -13,13 +13,14 @@
 # under the License.
 
 from networking_ccloud.common.config import config_driver as config
+from networking_ccloud.common import constants as cc_const
 from networking_ccloud.tests import base
 from networking_ccloud.tests.common import config_fixtures as cfix
 
 
 class TestDriverConfigValidation(base.TestCase):
-    def make_switch(self, name, host="1.2.3.4", vendor="arista"):
-        return config.Switch(name=name, host=host, vendor=vendor, user="admin", password="maunz",
+    def make_switch(self, name, host="1.2.3.4", platform=cc_const.PLATFORM_EOS):
+        return config.Switch(name=name, host=host, platform=platform, user="admin", password="maunz",
                              bgp_source_ip="2.3.4.5")
 
     def test_switchgroup_two_members(self):

--- a/networking_ccloud/tests/unit/ml2/agent/arista/test_config_updates.py
+++ b/networking_ccloud/tests/unit/ml2/agent/arista/test_config_updates.py
@@ -16,6 +16,7 @@ import re
 from unittest import mock
 
 from networking_ccloud.common.config import config_driver
+from networking_ccloud.common import constants as cc_const
 from networking_ccloud.ml2.agent.arista.switch import AristaSwitch
 from networking_ccloud.ml2.agent.common import messages
 from networking_ccloud.tests import base
@@ -24,7 +25,7 @@ from networking_ccloud.tests import base
 class TestAristaConfigUpdates(base.TestCase):
     def setUp(self):
         super().setUp()
-        cfg_switch = config_driver.Switch(name="seagull-sw1", host="127.0.0.1", vendor="arista",
+        cfg_switch = config_driver.Switch(name="seagull-sw1", host="127.0.0.1", platform=cc_const.PLATFORM_EOS,
                                           user="seagulladm", password="KRAKRAKRA", bgp_source_ip="1.1.1.1")
         self.switch = AristaSwitch(cfg_switch)
         self.switch._api = mock.Mock()

--- a/networking_ccloud/tools/agent_rpc_caller.py
+++ b/networking_ccloud/tools/agent_rpc_caller.py
@@ -29,7 +29,7 @@ CONF = cfg.CONF
 
 CLI_OPTS = [
     cfg.BoolOpt("driver", help="Communicate with the driver via RPC"),
-    cfg.StrOpt("agent", help="Communicate with an agent via RPC, vendor needs to be specified"),
+    cfg.StrOpt("agent", help="Communicate with an agent via RPC, platform needs to be specified"),
     cfg.StrOpt("method", default="status", help="Method you want to call on the other side (default status)"),
     cfg.ListOpt("args", default=[], help="Args to pass to method"),
 ]

--- a/networking_ccloud/tools/netbox_config_gen.py
+++ b/networking_ccloud/tools/netbox_config_gen.py
@@ -145,10 +145,10 @@ class ConfigGenerator:
         for leaf in leafs:
             switch_name = leaf.name
 
-            # vendor check!
-            vendor = leaf.device_type.manufacturer.slug
-            if vendor not in c_const.VENDORS:
-                print(f"Warning: Device {switch_name} is of vendor {vendor}, "
+            # platform check!
+            platform = leaf.platform.slug
+            if platform not in c_const.PLATFORMS:
+                print(f"Warning: Device {switch_name} is of platform {platform}, "
                       "which is not supported by the driver/config generator")
                 continue
 
@@ -215,7 +215,7 @@ class ConfigGenerator:
                 'name': switch_name,
                 'ports': switch_ports,
                 'hosts': host_ports,
-                'vendor': vendor,
+                'platform': platform,
                 'az': leaf.site.name,
             }
             switch.update(self.calculate_ccloud_switch_number_resources(leaf, kv_tags, region_asn))
@@ -261,7 +261,7 @@ class ConfigGenerator:
                 loopback1.add(nb_switch['loopback1'])
                 asn.add(nb_switch['asn'])
                 switch = conf.Switch(name=nb_switch['name'], host=nb_switch['host'],
-                                     bgp_source_ip=nb_switch['loopback0'], vendor=nb_switch['vendor'],
+                                     bgp_source_ip=nb_switch['loopback0'], platform=nb_switch['platform'],
                                      user=self.args.switch_user, password=self.args.switch_password)
 
                 switches.append(switch)


### PR DESCRIPTION
It was decided that we distinguish devices by their platform, not by
their vendor. So now we support arista-eos and cisco-nx-os!