### PR TITLE
Implement Network/Switch/SwitchGroup Sync API

### DIFF
--- a/networking_ccloud/common/exceptions.py
+++ b/networking_ccloud/common/exceptions.py
@@ -42,3 +42,7 @@ class OnlyOneAZHintAllowed(n_exc.BadRequest):
 
 class HostNetworkAZAffinityError(n_exc.BadRequest):
     message = "Host %(host)s resides in AZ %(hostgroup_az)s, network requires AZ %(network_az)s"
+
+
+class SwitchConnectionError(Exception):
+    pass

--- a/networking_ccloud/db/db_plugin.py
+++ b/networking_ccloud/db/db_plugin.py
@@ -159,20 +159,24 @@ class CCDbPlugin(db_base_plugin_v2.NeutronDbPluginV2,
         return azs
 
     @db_api.retry_if_session_inactive()
-    def get_interconnects_for_network(self, context, network_id, device_type=None):
+    def get_interconnects(self, context, network_id=None, device_type=None, host=None):
         query = context.session.query(cc_models.CCNetworkInterconnects)
-        filter_args = dict(network_id=network_id)
+        filter_args = {}
+        if network_id:
+            filter_args['network_id'] = network_id
         if device_type:
             filter_args['device_type'] = device_type
+        if host:
+            filter_args['host'] = host
         query = query.filter_by(**filter_args)
 
         return list(query.all())
 
     def get_transits_for_network(self, context, network_id):
-        return self.get_interconnects_for_network(context, network_id, cc_const.DEVICE_TYPE_TRANSIT)
+        return self.get_interconnects(context, network_id, cc_const.DEVICE_TYPE_TRANSIT)
 
     def get_bgws_for_network(self, context, network_id):
-        return self.get_interconnects_for_network(context, network_id, cc_const.DEVICE_TYPE_BGW)
+        return self.get_interconnects(context, network_id, cc_const.DEVICE_TYPE_BGW)
 
     @db_api.retry_if_session_inactive()
     def ensure_interconnect_for_network(self, context, device_type, network_id, az, only_own_az=False):

--- a/networking_ccloud/extensions/fabricoperations.py
+++ b/networking_ccloud/extensions/fabricoperations.py
@@ -306,9 +306,12 @@ class SwitchesController(wsgi.Controller):
                     di = device_info[switch['name']]
                     switch['device_info'] = {
                         'found': True,
-                        'version': di['version'],
-                        'uptime': di['uptime'],
+                        'reachable': di['reachable'],
+                        'version': di.get('version'),
+                        'uptime': di.get('uptime'),
                     }
+                    if 'error' in di:
+                        switch['device_error'] = di['error']
                 else:
                     switch['device_info'] = {'found': False}
 

--- a/networking_ccloud/extensions/fabricoperations.py
+++ b/networking_ccloud/extensions/fabricoperations.py
@@ -13,6 +13,8 @@
 #    under the License.
 
 import functools
+from itertools import groupby
+from operator import itemgetter
 
 from neutron.api import extensions
 from neutron.api.v2.resource import Resource
@@ -22,14 +24,16 @@ from neutron_lib.api import extensions as api_extensions
 from neutron_lib.api import faults
 from neutron_lib import exceptions as nl_exc
 from neutron_lib.plugins import directory
+from neutron_lib.plugins.ml2 import api as ml2_api
 from oslo_log import log as logging
 from webob import exc as web_exc
 
 from networking_ccloud.common.config import get_driver_config
-from networking_ccloud.db.db_plugin import CCDbPlugin
+from networking_ccloud.common import constants as cc_const
 import networking_ccloud.extensions
 from networking_ccloud.ml2.agent.common.api import CCFabricSwitchAgentRPCClient
 from networking_ccloud.ml2.agent.common import messages as agent_msg
+from networking_ccloud.ml2.plugin import FabricPlugin
 
 
 LOG = logging.getLogger(__name__)
@@ -47,31 +51,29 @@ def check_cloud_admin(f):
     return wrapper
 
 
-class Fabricoperations(api_extensions.ExtensionDescriptor):
+class FabricAPIDefinition:
+    NAME = "CC Fabric Driver API"
+    ALIAS = "cc-fabric-api"
+    DESCRIPTION = "CC Fabric driver API for extra driver functions"
+    UPDATED_TIMESTAMP = "2021-08-25T18:18:42+02:00"
+    RESOURCE_ATTRIBUTE_MAP = {}
+    SUB_RESOURCE_ATTRIBUTE_MAP = {}
+    REQUIRED_EXTENSIONS = []
+    OPTIONAL_EXTENSIONS = []
+
+
+class Fabricoperations(api_extensions.APIExtensionDescriptor):
     """CC fabric ml2 driver API extensions"""
     # class name cannot be camelcase, needs to be just capitalized
 
-    @classmethod
-    def get_name(cls):
-        return "CC Fabric Driver API"
+    api_definition = FabricAPIDefinition
 
     @classmethod
-    def get_alias(cls):
-        return "cc-fabric-api"
-
-    @classmethod
-    def get_description(cls):
-        return "CC Fabric driver API for extra driver functions"
-
-    @classmethod
-    def get_updated(cls):
-        """The timestamp when the extension was last updated."""
-        return "2021-08-25T18:18:42+02:00"
-
-    @classmethod
-    def _add_controller(cls, endpoints, ctrl, path):
+    def _add_controller(cls, endpoints, ctrl, path, parent=None, path_prefix='cc-fabric'):
+        member_actions = getattr(ctrl, "MEMBER_ACTIONS", None)
         res = Resource(ctrl, faults.FAULT_MAP)
-        ep = extensions.ResourceExtension(path, res)
+        ep = extensions.ResourceExtension(path, res, parent=parent, path_prefix=path_prefix,
+                                          member_actions=member_actions)
         endpoints.append(ep)
 
     @classmethod
@@ -81,13 +83,16 @@ class Fabricoperations(api_extensions.ExtensionDescriptor):
         Resources define new nouns, and are accessible through URLs.
         """
         endpoints = []
-        ep_name = 'cc-fabric'
-        db = CCDbPlugin()
+        fabric_plugin = FabricPlugin()
 
-        cls._add_controller(endpoints, StatusController(), f'{ep_name}/status')
-        cls._add_controller(endpoints, ConfigController(), f'{ep_name}/config')
-        cls._add_controller(endpoints, AgentCheckController(), f'{ep_name}/agent-check')
-        cls._add_controller(endpoints, SyncController(db), f'{ep_name}/sync')
+        cls._add_controller(endpoints, StatusController(), 'status')
+        cls._add_controller(endpoints, ConfigController(), 'config')
+        cls._add_controller(endpoints, AgentCheckController(), 'agent-check')
+
+        # "the new ones"
+        cls._add_controller(endpoints, FabricNetworksController(fabric_plugin), 'networks')
+        cls._add_controller(endpoints, SwitchesController(fabric_plugin), 'switches')
+        cls._add_controller(endpoints, SwitchgroupsController(fabric_plugin), 'switchgroups')
 
         return endpoints
 
@@ -95,6 +100,309 @@ class Fabricoperations(api_extensions.ExtensionDescriptor):
 def register_api_extension():
     extensions.register_custom_supported_check(Fabricoperations.get_alias(), lambda: True, True)
     extensions.append_api_extensions_path(networking_ccloud.extensions.__path__)
+
+
+class FabricNetworksController(wsgi.Controller):
+    """Show network info"""
+    MEMBER_ACTIONS = {'diff': 'GET', 'sync': 'PUT', 'ensure_interconnects': 'PUT'}
+
+    def __init__(self, fabric_plugin):
+        super().__init__()
+        self.fabric_plugin = fabric_plugin
+        self.drv_conf = get_driver_config()
+        self.plugin = directory.get_plugin()
+
+    @check_cloud_admin
+    def index(self, request, **kwargs):
+        raise web_exc.HTTPBadRequest("Index not available for this resource")
+
+    @check_cloud_admin
+    def update(self, request, **kwargs):
+        raise web_exc.HTTPBadRequest("update not available for this resource")
+
+    @check_cloud_admin
+    def show(self, request, **kwargs):
+        """Show what we know about a network"""
+        # make sure network exists
+        network_id = kwargs.pop('id')
+        net = self.plugin.get_network(request.context, network_id)
+
+        # fetch interconnects
+        interconnects_db = self.fabric_plugin.get_interconnects(request.context, network_id=network_id)
+        interconnects = [dict(host=i.host, device_type=i.device_type, availability_zone=i.availability_zone)
+                         for i in interconnects_db]
+        # FIXME: check if network has all the interconnects it needs
+
+        # fetch binding hosts
+        hosts_db = self.fabric_plugin.get_hosts_on_segments(request.context, network_ids=[network_id])
+        hosts = [h for h in hosts_db.get(network_id, [])]
+
+        # FIXME: add on which switches / switchgroups the network is present
+
+        return {
+            'id': net['id'],
+            'hosts': hosts,
+            'interconnects': interconnects,
+        }
+
+    @check_cloud_admin
+    def diff(self, request, **kwargs):
+        # make sure network exists
+        network_id = kwargs.pop('id')
+        self.plugin.get_network(request.context, network_id)
+        # FIXME: get config from device, diff them
+
+        print("Got diff request", request, kwargs)
+        raise web_exc.HTTPNotImplemented("Network diff is not implemented yet")
+
+    @check_cloud_admin
+    def sync(self, request, **kwargs):
+        # make sure network exists
+        network_id = kwargs.pop('id')
+        self.plugin.get_network(request.context, network_id)
+
+        LOG.info("Got API request for syncing network %s", network_id)
+        scul = self._make_config_from_network(request.context, network_id)
+        config_generated = scul.execute(request.context)
+        return {'sync_sent': config_generated}
+
+    @check_cloud_admin
+    def ensure_interconnects(self, request, **kwargs):
+        # make sure network exists
+        network_id = kwargs.pop('id')
+        network = self.plugin.get_network(request.context, network_id)
+
+        created, errors = self.fabric_plugin.allocate_and_configure_interconnects(request.context, network)
+
+        return {
+            'network_id': network_id,
+            'interconnects_allocated': created,
+            'error_on_allocation': errors,
+        }
+
+    def _make_config_from_network(self, context, network_id):
+        scul = agent_msg.SwitchConfigUpdateList(agent_msg.OperationEnum.add, self.drv_conf)
+
+        top_segments = self.fabric_plugin.get_top_level_vxlan_segments(context, network_ids=[network_id])
+        if network_id not in top_segments:
+            raise web_exc.HTTPInternalServerError(f"Network id {network_id} is missing its top level vxlan segment")
+        vni = top_segments[network_id]['segmentation_id']
+
+        net_segments = self.fabric_plugin.get_hosts_on_segments(context, network_ids=[network_id])
+        if network_id not in net_segments:
+            raise web_exc.HTTPInternalServerError(f"Network id {network_id} has segments attached to it")
+
+        for binding_host, segment_1 in net_segments[network_id].items():
+            vlan = segment_1['segmentation_id']
+            hg_config = self.drv_conf.get_hostgroup_by_host(binding_host)
+            if not hg_config:
+                LOG.error("Got a port binding for binding host %s in network %s, which was not found in config",
+                          binding_host, network_id)
+                continue
+            # FIXME: handle trunk_vlans
+            # FIXME: exclude_hosts
+            # FIXME: direct binding hosts? are they included?
+            scul.add_binding_host_to_config(hg_config, network_id, vni, vlan)
+
+        interconnects = self.fabric_plugin.get_interconnects(context, network_id=network_id)
+        for device in interconnects:
+            device_hg = self.drv_conf.get_hostgroup_by_host(device.host)
+            if not device_hg:
+                LOG.error("Could not bind device type %s host %s in network %s: Host not found in config",
+                          device.device_type, device.host, network_id)
+                continue
+
+            device_physnet = device_hg.get_vlan_pool_name(self.drv_conf)
+            device_segment = self.fabric_plugin.get_segment_by_host(context, network_id, device_physnet)
+            if not device_segment:
+                LOG.error("Missing network segment for interconnect %s physnet %s in network %s",
+                          device.host, device_physnet, network_id)
+                continue
+
+            scul.add_binding_host_to_config(device_hg, network_id, vni, device_segment[ml2_api.SEGMENTATION_ID],
+                                            is_bgw=device.device_type == cc_const.DEVICE_TYPE_BGW)
+
+        return scul
+
+
+class SwitchesController(wsgi.Controller):
+    """List and show Switches from config"""
+    MEMBER_ACTIONS = {'diff': 'GET', 'sync': 'PUT', 'sync_infra_networks': 'PUT'}
+
+    def __init__(self, fabric_plugin):
+        super().__init__()
+        self.fabric_plugin = fabric_plugin
+        self.drv_conf = get_driver_config()
+
+    @classmethod
+    def _make_switch_dict(cls, switch, sg):
+        return dict(name=switch.name, platform=switch.platform, availability_zone=sg.availability_zone,
+                    switchgroup=sg.name)
+
+    def _get_switch(self, switch_name):
+        for sg in self.drv_conf.switchgroups:
+            for switch in sg.members:
+                if switch.name == switch_name:
+                    return switch, sg
+        else:
+            raise nl_exc.ObjectNotFound(id=switch_name)
+
+    @check_cloud_admin
+    def index(self, request, **kwargs):
+        switches = [self._make_switch_dict(switch, sg) for sg in self.drv_conf.switchgroups for switch in sg.members]
+
+        if request.params.get('device_info'):
+            self._add_device_info(request.context, switches)
+
+        return switches
+
+    @check_cloud_admin
+    def show(self, request, **kwargs):
+        switch = self._make_switch_dict(*self._get_switch(kwargs.pop('id')))
+        if request.params.get('device_info'):
+            self._add_device_info(request.context, [switch])
+
+        return switch
+
+    @check_cloud_admin
+    def diff(self, request, **kwargs):
+        switch, sg = self._get_switch(kwargs.pop('id'))
+
+        print("Got diff request", request, kwargs)
+        raise web_exc.HTTPNotImplemented("Switch diff is not implemented yet")
+
+    @check_cloud_admin
+    def sync(self, request, **kwargs):
+        switch, sg = self._get_switch(kwargs.pop('id'))
+
+        LOG.info("Got API request for syncing switch %s", switch.name)
+        scul = self._make_switch_config(request.context, switch, sg)
+        config_generated = scul.execute(request.context)
+        return {'sync_sent': config_generated}
+
+    @check_cloud_admin
+    def sync_infra_networks(self, request, **kwargs):
+        switch, sg = self._get_switch(kwargs.pop('id'))
+
+        LOG.info("Got API request for syncing infra networks of %s", switch.name)
+        scul = agent_msg.SwitchConfigUpdateList(agent_msg.OperationEnum.replace, self.drv_conf)
+        for hg in self.drv_conf.get_hostgroups_by_switch(switch.name):
+            if hg.infra_networks:
+                for inet in hg.infra_networks:
+                    # FIXME: exclude hosts
+                    scul.add_binding_host_to_config(hg, inet.name, inet.vni, inet.vlan)
+        self._clean_switches(scul, switch)
+        config_generated = scul.execute(request.context)
+        return {'sync_sent': config_generated}
+
+    def _add_device_info(self, context, switches):
+        for platform, switches in groupby(sorted(switches, key=itemgetter('platform')), key=itemgetter('platform')):
+            switches = list(switches)
+            switch_names = [s['name'] for s in switches]
+            rpc_client = CCFabricSwitchAgentRPCClient.get_for_platform(platform)
+            device_info = rpc_client.get_switch_status(context, switches=switch_names)
+            for switch in switches:
+                if switch['name'] in device_info:
+                    di = device_info[switch['name']]
+                    switch['device_info'] = {
+                        'found': True,
+                        'version': di['version'],
+                        'uptime': di['uptime'],
+                    }
+                else:
+                    switch['device_info'] = {'found': False}
+
+    def _make_switch_config(self, context, switch, sg):
+        scul = agent_msg.SwitchConfigUpdateList(agent_msg.OperationEnum.replace, self.drv_conf)
+
+        # physnets of this switch, which is the switch's switchgroup's vlan pool
+        physnets = [sg.vlan_pool]
+
+        # get all binding hosts bound onto that switch
+        #   + interconnects
+        #   + infra networks
+        net_segments = self.fabric_plugin.get_hosts_on_segments(context, physical_networks=physnets)
+        top_segments = self.fabric_plugin.get_top_level_vxlan_segments(context, network_ids=list(net_segments.keys()))
+        scul.add_segments(net_segments, top_segments)
+
+        for hg in self.drv_conf.get_hostgroups_by_switch(switch.name):
+            if hg.infra_networks:
+                for inet in hg.infra_networks:
+                    # FIXME: exclude hosts
+                    scul.add_binding_host_to_config(hg, inet.name, inet.vni, inet.vlan)
+            if hg.role:
+                # transits/BGWs don't have bindings, so bind all physnets
+                # find all physnets or interconnects scheduled
+                interconnects = self.fabric_plugin.get_interconnects(context, host=hg.binding_hosts[0])
+                scul.add_interconnects(context, self.fabric_plugin, interconnects)
+
+        self._clean_switches(scul, switch)
+        return scul
+
+    def _clean_switches(self, scul, switch):
+        # make sure we only sync that one switch
+        for cfg_switch in list(scul.switch_config_updates):
+            if cfg_switch != switch.name:
+                del scul.switch_config_updates[cfg_switch]
+
+
+class SwitchgroupsController(wsgi.Controller):
+    """List and show SwitchGroups from config"""
+
+    MEMBER_ACTIONS = {'diff': 'GET', 'sync': 'PUT', 'sync_infra_networks': 'PUT'}
+
+    def __init__(self, fabric_plugin):
+        super().__init__()
+        self.fabric_plugin = fabric_plugin
+        self.drv_conf = get_driver_config()
+        self._swctrl = SwitchesController(fabric_plugin)
+
+    @classmethod
+    def _make_sg_dict(cls, sg):
+        return dict(name=sg.name, availability_zone=sg.availability_zone,
+                    members=[s.name for s in sg.members])
+
+    @check_cloud_admin
+    def index(self, request, **kwargs):
+        # FIXM support device_info?
+        return [self._make_sg_dict(sg) for sg in self.drv_conf.switchgroups]
+
+    @check_cloud_admin
+    def show(self, request, **kwargs):
+        # FIXME support device_info parameter?
+        sg = self._get_switchgroup(kwargs.pop('id'))
+        return self._make_sg_dict(sg)
+
+    @check_cloud_admin
+    def diff(self, request, **kwargs):
+        sg = self._get_switchgroup(kwargs.pop('id'))
+        result = {}
+        for member in sg.members:
+            result[member.name] = self._swctrl.diff(request, id=member.name)
+        return result
+
+    @check_cloud_admin
+    def sync(self, request, **kwargs):
+        sg = self._get_switchgroup(kwargs.pop('id'))
+        result = {}
+        for member in sg.members:
+            result[member.name] = self._swctrl.sync(request, id=member.name)
+        return result
+
+    @check_cloud_admin
+    def sync_infra_networks(self, request, **kwargs):
+        sg = self._get_switchgroup(kwargs.pop('id'))
+        result = {}
+        for member in sg.members:
+            result[member.name] = self._swctrl.sync_infra_networks(request, id=member.name)
+        return result
+
+    def _get_switchgroup(self, sg_name):
+        for sg in self.drv_conf.switchgroups:
+            if sg.name == sg_name:
+                return sg
+        else:
+            raise nl_exc.ObjectNotFound(id=sg_name)
 
 
 class StatusController(wsgi.Controller):
@@ -144,105 +452,3 @@ class AgentCheckController(wsgi.Controller):
             resp.append(agent_resp)
 
         return resp
-
-
-class SyncController(wsgi.Controller):
-    def __init__(self, db):
-        super().__init__()
-        self.db = db
-        self.drv_conf = get_driver_config()
-        self.plugin = directory.get_plugin()
-
-    @check_cloud_admin
-    def index(self, request, **kwargs):
-        return {"driver_reached": True}
-
-    @check_cloud_admin
-    def show(self, request, **kwargs):
-        obj_type = kwargs.pop("id")
-        # FIXME: Is this validation something we could do via an API scheme?
-        if obj_type not in ("switches", "networks"):
-            raise web_exc.HTTPBadRequest("Invalid sync option, please choose either switches or networks")
-
-        objs = request.params.getall('obj')
-        if not isinstance(objs, list) or not all(isinstance(e, str) for e in objs):
-            raise web_exc.HTTPBadRequest("Payload must be a list of strings")
-
-        if not objs:
-            raise web_exc.HTTPBadRequest(f"Please provide at least one object identifier for the {obj_type} "
-                                         f"you want to work with")
-
-        # FIXME: command via GET is nothing we should do in the end product, fix this to proper API something
-        # FIXME: write proper tests for this sync logic
-        cmd = request.params.get('cmd', 'config')
-        if cmd not in ('config', 'diff', 'sync'):
-            raise web_exc.HTTPBadRequest(f"Cmd '{cmd}' is invalid, choose from config, diff, sync")
-
-        filter_switches = None
-        LOG.error("Test ctx %s sess %s", request.context, getattr(request.context, "session", None))
-        if obj_type == "networks":
-            # validate that all networks exist
-            for network_id in objs:
-                try:
-                    self.plugin.get_network(request.context, network_id)
-                except nl_exc.NetworkNotFound as e:
-                    raise web_exc.HTTPBadRequest(str(e))
-
-            # query db for physnets'n'stuff
-            # create config update list for each bindinghost of each network
-            scul = agent_msg.SwitchConfigUpdateList(agent_msg.OperationEnum.add, self.drv_conf)
-            net_segments = self.db.get_hosts_on_segments(request.context, network_ids=objs)
-        elif obj_type == "switches":
-            # make sure switches exist and get their attached physnets
-            physnets = []
-            for switch in objs:
-                if not self.drv_conf.get_switch_by_name(switch):
-                    raise web_exc.HTTPBadRequest(f"Switch '{switch}' does not exist in current driver's switch config")
-                # FIXME: can we have switches without a switchgroup?
-                sg = self.drv_conf.get_switchgroup_by_switch_name(switch)
-                physnets.append(sg.vlan_pool)
-
-            filter_switches = objs
-            # query db
-            net_segments = self.db.get_hosts_on_segments(request.context, physical_networks=physnets)
-            scul = agent_msg.SwitchConfigUpdateList(agent_msg.OperationEnum.replace, self.drv_conf)
-        else:
-            raise Exception(f"Unhandled mode '{obj_type}', should've been catched before - inform the developers -.-")
-
-        top_segments = self.db.get_top_level_vxlan_segments(request.context, network_ids=list(net_segments.keys()))
-        for network_id, segments in net_segments.items():
-            if network_id not in top_segments:
-                raise web_exc.HTTPInternalServerError(f"Network id {network_id} is missing its top level vxlan segment")
-
-            segment_0 = top_segments[network_id]
-            vni = segment_0['segmentation_id']
-
-            for binding_host, segment_1 in segments.items():
-                vlan = segment_1['segmentation_id']
-                hg_config = self.drv_conf.get_hostgroup_by_host(binding_host)
-                if not hg_config:
-                    LOG.error("Got a port binding for binding host %s in network %s, which was not found in config",
-                              binding_host, network_id)
-                    continue
-                # FIXME: handle trunk_vlans
-                # FIXME: exclude_hosts
-                # FIXME: direct binding hosts? are they included?
-                scul.add_binding_host_to_config(hg_config, network_id, vni, vlan)
-
-        # FIXME: make sure no other switch jumped into this if the user requested a special set of switches
-        if filter_switches is not None:
-            switch_remove_list = set(sn for sn in scul.switch_config_updates if sn not in filter_switches)
-            for switch_name in switch_remove_list:
-                del scul.switch_config_updates[switch_name]
-
-        if cmd == 'config':
-            return {
-                'switch_configs': {k: v.dict() for k, v in scul.switch_config_updates.items()},
-            }
-        elif cmd == 'diff':
-            return {'error': 'Diff not implemented'}
-        elif cmd == 'sync':
-            if scul.execute():
-                return {'sync': 'ok'}
-            else:
-                return {'sync': 'no_config'}

--- a/networking_ccloud/ml2/agent/common/agent.py
+++ b/networking_ccloud/ml2/agent/common/agent.py
@@ -150,13 +150,12 @@ class CCFabricSwitchAgent(manager.Manager, cc_agent_api.CCFabricSwitchAgentAPI):
 
          :param list switches: List of switch names or primary addresses to filter for
          """
-        LOG.info("Welcome to the RPC call!")
-        result = []
+        result = {'switches': {}}
         for switch in self._switches:
+            if switches and switch not in switches:
+                continue
             # FIXME: handle offline switches (will probably require changing the response format)
-            # FIXME: filter, if switches is set
-            LOG.info("Testing switch %s", switch)
-            result.append(switch.get_switch_status())
+            result['switches'][switch.name] = switch.get_switch_status()
         return result
 
     def apply_config_update(self, context, config):

--- a/networking_ccloud/ml2/agent/common/agent.py
+++ b/networking_ccloud/ml2/agent/common/agent.py
@@ -96,7 +96,7 @@ class CCFabricSwitchAgent(manager.Manager, cc_agent_api.CCFabricSwitchAgentAPI):
         return None
 
     def init_host(self):
-        LOG.error("Initializing agent %s with topic %s", self.get_binary_name(), self.get_agent_topic())
+        LOG.info("Initializing agent %s with topic %s", self.get_binary_name(), self.get_agent_topic())
         self._init_switches()
 
     def after_start(self):

--- a/networking_ccloud/ml2/mech_driver.py
+++ b/networking_ccloud/ml2/mech_driver.py
@@ -297,8 +297,15 @@ class CCFabricMechanismDriver(ml2_api.MechanismDriver, CCFabricDriverAPI):
         # collect data for other process
         devices = []
         for device in self.fabric_plugin.get_interconnects(context._plugin_context, network_id):
+            device_hg = self.drv_conf.get_hostgroup_by_host(device.host)
+            if not device_hg:
+                LOG.error("Could not delete device %s host %s in network %s: Host not found in config",
+                          device.device_type, device.host, device.network_id)
+                continue
+
+            device_physnet = device_hg.get_vlan_pool_name(self.drv_conf)
             seg = self.fabric_plugin.get_segment_by_host(context._plugin_context,
-                                                         network_id=network_id, physical_network=device.host)
+                                                         network_id=network_id, physical_network=device_physnet)
             if not seg:
                 LOG.warning("Cannot deconfigure %s %s for network %s - no segment found in database",
                             device.device_type, device.host, network_id)

--- a/networking_ccloud/ml2/plugin.py
+++ b/networking_ccloud/ml2/plugin.py
@@ -1,0 +1,124 @@
+# Copyright 2022 SAP SE
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from neutron.db import segments_db
+from neutron_lib.api.definitions import availability_zone as az_api
+from neutron_lib.callbacks import events
+from neutron_lib.callbacks import registry
+from neutron_lib import constants as nl_const
+from neutron_lib.plugins import directory
+from neutron_lib.plugins.ml2 import api as ml2_api
+from oslo_log import log as logging
+
+from networking_ccloud.common import constants as cc_const
+from networking_ccloud.db.db_plugin import CCDbPlugin
+from networking_ccloud.ml2.agent.common import messages as agent_msg
+
+
+LOG = logging.getLogger(__name__)
+
+
+class FabricPlugin(CCDbPlugin):
+    def __init__(self):
+        super().__init__()
+
+        self._plugin_property = None
+
+    @property
+    def _plugin(self):
+        if self._plugin_property is None:
+            self._plugin_property = directory.get_plugin()
+        return self._plugin_property
+
+    def allocate_and_configure_interconnects(self, context, network):
+        """Allocate and configure interconnects for a network
+
+        Returns two bools (new_allocation, error)
+        """
+        errors_found = False
+        new_allocation = False
+
+        # find top level segment
+        network_id = network['id']
+        top_segments = self.get_top_level_vxlan_segments(context, network_ids=[network_id])
+        if network_id not in top_segments:
+            LOG.error("Network %s has no top level segment (vxlan / physnet None), aborting transit/BGW scheduling",
+                      network_id)
+            return False, False
+        segment_0 = top_segments[network_id]
+
+        # allocate network interconnects (BGWs / Transits)
+        az_hints = network.get(az_api.AZ_HINTS, [])
+        created_transits = []
+        scul = agent_msg.SwitchConfigUpdateList(agent_msg.OperationEnum.add, self.drv_conf)
+
+        net_azs = az_hints or self.drv_conf.list_availability_zones()
+        for az in net_azs:
+            for device_type in (cc_const.DEVICE_TYPE_BGW, cc_const.DEVICE_TYPE_TRANSIT):
+                if device_type == cc_const.DEVICE_TYPE_BGW and az_hints:
+                    # we don't allocate BGWs for AZ-local networks
+                    continue
+
+                device_created, device = self.ensure_interconnect_for_network(context, device_type,
+                                                                              network_id, az,
+                                                                              only_own_az=bool(az_hints))
+                if not device_created:
+                    # no config needed, already allocated
+                    continue
+
+                # new device allocated, create a segment and add the host to scul
+                device_hg = self.drv_conf.get_hostgroup_by_host(device.host)
+                if not device_hg:
+                    LOG.error("Could not bind device type %s host %s in network %s: Host not found in config",
+                              device_type, device.host, network_id)
+                    errors_found = True
+                    continue
+
+                device_physnet = device_hg.get_vlan_pool_name(self.drv_conf)
+                segment_spec = {
+                    ml2_api.NETWORK_TYPE: nl_const.TYPE_VLAN,
+                    ml2_api.PHYSICAL_NETWORK: device_physnet,
+                }
+                device_segment = self._plugin.type_manager.allocate_dynamic_segment(context, network_id,
+                                                                                    segment_spec)
+                scul.add_binding_host_to_config(device_hg, network_id,
+                                                segment_0[ml2_api.SEGMENTATION_ID],
+                                                device_segment[ml2_api.SEGMENTATION_ID],
+                                                is_bgw=device_type == cc_const.DEVICE_TYPE_BGW)
+                if device_type == cc_const.DEVICE_TYPE_TRANSIT:
+                    # add to notify list later on
+                    created_transits.append((az, device.host, device_segment['id'], device_physnet))
+
+                LOG.info("Allocated device %s to %s for network %s in az %s on vlan %s",
+                         device_type, device.host, network_id, az, device_segment[ml2_api.SEGMENTATION_ID])
+                new_allocation = True
+
+        if new_allocation and not scul.execute(context):
+            LOG.warning("Scheduling network interconnects for network %s yielded no config updates", network_id)
+
+        for az, host, segment_id, physnet in created_transits:
+            # notify others
+            LOG.debug("Sending out notify for transit creation on %s for host %s az %s segment %s",
+                      network_id, host, az, segment_id)
+            payload_metadata = {
+                'network_id': network_id,
+                'availability_zone': az,
+                'host': host,
+                'segment_id': segment_id,
+                'physical_network': physnet,
+            }
+            payload = events.DBEventPayload(context, metadata=payload_metadata)
+            registry.publish(cc_const.CC_TRANSIT, events.AFTER_CREATE, self, payload=payload)
+
+        return new_allocation, errors_found

--- a/networking_ccloud/ml2/plugin.py
+++ b/networking_ccloud/ml2/plugin.py
@@ -12,7 +12,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from neutron.db import segments_db
 from neutron_lib.api.definitions import availability_zone as az_api
 from neutron_lib.callbacks import events
 from neutron_lib.callbacks import registry

--- a/networking_ccloud/tests/unit/extensions/test_extensions.py
+++ b/networking_ccloud/tests/unit/extensions/test_extensions.py
@@ -11,15 +11,25 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from unittest import mock
 
 from neutron.api import extensions
+from neutron.db.models import segment as segment_models
 from neutron.tests.unit.api.test_extensions import setup_extensions_middleware
+from neutron.tests.unit.extensions import test_segment
+from neutron_lib import context
+from neutron_lib.plugins.ml2 import api as ml2_api
 import webtest
 
 from networking_ccloud.common.config import _override_driver_config
+from networking_ccloud.common.config.config_driver import InfraNetwork
+from networking_ccloud.common import constants as cc_const
+from networking_ccloud.db.db_plugin import CCDbPlugin
 from networking_ccloud.extensions import __path__ as fabric_ext_path
 from networking_ccloud.extensions import fabricoperations
+from networking_ccloud.ml2.agent.common.api import CCFabricSwitchAgentRPCClient
 from networking_ccloud.tests import base
+from networking_ccloud.tests.common import config_fixtures as cfix
 
 
 class TestCustomExtension(base.TestCase):
@@ -40,3 +50,245 @@ class TestCustomExtension(base.TestCase):
     def test_extension_status(self):
         resp = self.app.get("/cc-fabric/status")
         self.assertEqual({'driver_reached': True}, resp.json)
+
+
+class TestSyncExtension(base.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        _override_driver_config(123)  # FIXME proper fake config
+        self.ext_mgr = extensions.ExtensionManager(fabric_ext_path[0])
+        self.app = webtest.TestApp(setup_extensions_middleware(self.ext_mgr))
+
+    def test_extension_status(self):
+        resp = self.app.get("/cc-fabric/status")
+        self.assertEqual({'driver_reached': True}, resp.json)
+
+
+class TestNetworkExtension(test_segment.SegmentTestCase, base.PortBindingHelper):
+    def setUp(self):
+        super().setUp()
+
+        # make config
+        switchgroups = [
+            cfix.make_switchgroup("seagull", availability_zone="qa-de-1a"),
+            cfix.make_switchgroup("transit1", availability_zone="qa-de-1a"),
+            cfix.make_switchgroup("bgw1", availability_zone="qa-de-1a"),
+
+            cfix.make_switchgroup("crow", availability_zone="qa-de-1b"),
+            cfix.make_switchgroup("transit2", availability_zone="qa-de-1b"),
+            cfix.make_switchgroup("bgw2", availability_zone="qa-de-1b"),
+
+            cfix.make_switchgroup("sentinel", availability_zone="qa-de-1a",
+                                  switch_vars=dict(platform=cc_const.PLATFORM_EOS)),
+        ]
+        seagull_infra_nets = [
+            # FIXME: networks entry needs to be a CIDR, but bug in config doesn't allow that
+            InfraNetwork(name="infra_net_l3", vlan=23, networks=["10.23.42.1"], vni=6667),
+            InfraNetwork(name="infra_net_vlan", vlan=42),
+        ]
+        hg_seagull = cfix.make_metagroup("seagull", meta_kwargs={'infra_networks': seagull_infra_nets})
+        hg_crow = cfix.make_metagroup("crow")
+        interconnects = [
+            cfix.make_interconnect(cc_const.DEVICE_TYPE_TRANSIT, "transit1", "transit1", ["qa-de-1a"]),
+            cfix.make_interconnect(cc_const.DEVICE_TYPE_TRANSIT, "transit2", "transit2", ["qa-de-1b"]),
+            cfix.make_interconnect(cc_const.DEVICE_TYPE_BGW, "bgw1", "bgw1", ["qa-de-1a"]),
+            cfix.make_interconnect(cc_const.DEVICE_TYPE_BGW, "bgw2", "bgw2", ["qa-de-1b"]),
+        ]
+        hostgroups = hg_seagull + hg_crow + interconnects
+
+        self.conf_drv = cfix.make_config(switchgroups=switchgroups, hostgroups=hostgroups)
+        _override_driver_config(self.conf_drv)
+        self.db = CCDbPlugin()
+        self.ctx = context.get_admin_context()
+
+        self._net_a = self._make_network(name="a", admin_state_up=True, fmt='json')['network']
+        for az in ('a', 'b'):
+            self.db.ensure_bgw_for_network(self.ctx, self._net_a['id'], f"qa-de-1{az}")
+            self.db.ensure_transit_for_network(self.ctx, self._net_a['id'], f"qa-de-1{az}")
+
+        self._seg_a = {physnet: self._make_segment(network_id=self._net_a['id'], network_type='vlan',
+                       physical_network=physnet, segmentation_id=seg_id, tenant_id='test-tenant',
+                       fmt='json')['segment']
+                       for physnet, seg_id in (('seagull', 100), ('crow', 200), ('bgw1', 234), ('bgw2', 345),
+                                               ('transit1', 111), ('transit2', 222))}
+        self._seg_a[None] = self._make_segment(network_id=self._net_a['id'], network_type='vxlan',
+                                               segmentation_id=232323,
+                                               tenant_id="test-tenant", fmt='json')['segment']
+        self._port_a_1 = self._make_port_with_binding(segments=[(self._seg_a[None], 'cc-fabric'),
+                                                                (self._seg_a['seagull'], 'meow-ml2')],
+                                                      host='nova-compute-seagull')
+        self._port_a_2 = self._make_port_with_binding(segments=[(self._seg_a[None], 'cc-fabric'),
+                                                                (self._seg_a['crow'], 'meow-ml2')],
+                                                      host='nova-compute-crow')
+
+        # fix segment index
+        with self.ctx.session.begin():
+            objs = self.ctx.session.query(segment_models.NetworkSegment).filter_by(physical_network=None,
+                                                                                   network_type='vxlan')
+            objs.update({'segment_index': 0})
+
+        self.ext_mgr = extensions.ExtensionManager(fabric_ext_path[0])
+        self.app = webtest.TestApp(setup_extensions_middleware(self.ext_mgr))
+
+    def test_network_get(self):
+        resp = self.app.get(f"/cc-fabric/networks/{self._net_a['id']}")
+        net = resp.json
+        self.assertEqual({'nova-compute-seagull', 'nova-compute-crow'}, set(net['hosts']))
+        self.assertEqual(4, len(net['interconnects']))
+        self.assertEqual({'bgw', 'transit'}, {ic['device_type'] for ic in net['interconnects']})
+
+    def test_network_ensure_interconnects(self):
+        with self.network() as network:
+            network_id = network['network']['id']
+            self._make_segment(network_id=network_id, network_type='vxlan',
+                               segmentation_id=424242,
+                               tenant_id="test-tenant", fmt='json')['segment']
+
+            # make sure nothing is allocated
+            self.assertEqual([], self.db.get_interconnects(self.ctx, network_id))
+
+            # make apicall
+            fake_new_segment = {'id': 'my-uuid', ml2_api.SEGMENTATION_ID: 1234}
+            with mock.patch.object(test_segment.SegmentTestPlugin, 'type_manager', create=True) as mock_tm, \
+                    mock.patch.object(CCFabricSwitchAgentRPCClient, 'apply_config_update') as mock_acu:
+                mock_tm.allocate_dynamic_segment.return_value = fake_new_segment
+                self.app.put(f"/cc-fabric/networks/{network_id}/ensure_interconnects")
+                mock_tm.allocate_dynamic_segment.assert_called()
+                mock_acu.assert_called()
+
+            # make sure interconnects are now present
+            self.assertEqual(4, len(self.db.get_interconnects(self.ctx, network_id)))
+
+    def test_network_sync(self):
+        with mock.patch.object(CCFabricSwitchAgentRPCClient, 'apply_config_update') as mock_acu:
+            resp = self.app.put(f"/cc-fabric/networks/{self._net_a['id']}/sync")
+            self.assertTrue(resp.json['sync_sent'])
+            mock_acu.assert_called()
+            swcfg = mock_acu.call_args[0][1]
+            self.assertEqual({"seagull-sw1", "seagull-sw2", "crow-sw1", "crow-sw2",
+                              "transit1-sw1", "transit2-sw1", "bgw1-sw1", "bgw2-sw1"},
+                             set(s.switch_name for s in swcfg))
+
+            # FIXME: check that all necessary switches are synced
+
+    def test_switches(self):
+        # index
+        resp = self.app.get("/cc-fabric/switches")
+        switches = resp.json
+        self.assertEqual(14, len(switches))
+        self.assertEqual("seagull-sw1", switches[0]['name'])
+
+        # detail
+        resp = self.app.get("/cc-fabric/switches/seagull-sw1")
+        switch = resp.json
+        self.assertEqual("seagull-sw1", switch['name'])
+
+    def test_switches_with_info(self):
+        def fake_get_switch_status(context, switches):
+            return {switch: {'found': True, 'uptime': '23 s', 'version': 'Windows 95'} for switch in switches}
+
+        with mock.patch.object(CCFabricSwitchAgentRPCClient, 'get_switch_status',
+                               side_effect=fake_get_switch_status) as mock_gss:
+            # index
+            resp = self.app.get("/cc-fabric/switches?device_info=1")
+            switches = resp.json
+            self.assertEqual(14, len(switches))
+            self.assertEqual("seagull-sw1", switches[0]['name'])
+            self.assertTrue(all(s['device_info']['found'] for s in switches))
+            self.assertEqual(2, mock_gss.call_count)
+            mock_gss.reset_mock()
+
+            # detail
+            resp = self.app.get("/cc-fabric/switches/seagull-sw1?device_info=1")
+            switch = resp.json
+            self.assertEqual("seagull-sw1", switch['name'])
+            self.assertTrue(switch['device_info']['found'])
+            mock_gss.assert_called_once()
+
+    def test_switch_sync_vpod(self):
+        with mock.patch.object(CCFabricSwitchAgentRPCClient, 'apply_config_update') as mock_acu:
+            resp = self.app.put("/cc-fabric/switches/seagull-sw1/sync")
+            self.assertTrue(resp.json['sync_sent'])
+            mock_acu.assert_called()
+            swcfgs = mock_acu.call_args[0][1]
+
+            # assert only this one switch was synced and nothing else
+            self.assertEqual({"seagull-sw1"}, set(s.switch_name for s in swcfgs))
+
+            # check that infra networks and portbindings are synced
+            for swcfg in swcfgs:
+                for iface in swcfg.ifaces:
+                    self.assertEqual({23, 42, 100}, set(iface.trunk_vlans))
+
+    def test_switch_sync_vpod_infra_networks(self):
+        with mock.patch.object(CCFabricSwitchAgentRPCClient, 'apply_config_update') as mock_acu:
+            resp = self.app.put("/cc-fabric/switches/seagull-sw1/sync_infra_networks")
+            self.assertTrue(resp.json['sync_sent'])
+            mock_acu.assert_called()
+            swcfgs = mock_acu.call_args[0][1]
+            self.assertEqual({"seagull-sw1"}, set(s.switch_name for s in swcfgs))
+            for swcfg in swcfgs:
+                for iface in swcfg.ifaces:
+                    self.assertEqual({23, 42}, set(iface.trunk_vlans))
+
+    def test_switch_sync_interconnect_bgw(self):
+        with mock.patch.object(CCFabricSwitchAgentRPCClient, 'apply_config_update') as mock_acu:
+            resp = self.app.put("/cc-fabric/switches/bgw1-sw1/sync")
+            self.assertTrue(resp.json['sync_sent'])
+            mock_acu.assert_called()
+            swcfgs = mock_acu.call_args[0][1]
+            self.assertEqual({"bgw1-sw1"}, set(s.switch_name for s in swcfgs))
+            for swcfg in swcfgs:
+                self.assertIsNone(swcfg.ifaces)
+                self.assertEqual({234}, {v.vlan for v in swcfg.vlans})
+
+    def test_switch_sync_interconnect_bgw_infranetworks_empty(self):
+        with mock.patch.object(CCFabricSwitchAgentRPCClient, 'apply_config_update') as mock_acu:
+            # bgw1 has no infra networks --> should be a noop
+            resp = self.app.put("/cc-fabric/switches/bgw1-sw1/sync_infra_networks")
+            self.assertFalse(resp.json['sync_sent'])
+            mock_acu.assert_not_called()
+
+    def test_switch_sync_interconnect_transit(self):
+        with mock.patch.object(CCFabricSwitchAgentRPCClient, 'apply_config_update') as mock_acu:
+            resp = self.app.put("/cc-fabric/switches/transit1-sw1/sync")
+            self.assertTrue(resp.json['sync_sent'])
+            mock_acu.assert_called()
+            swcfgs = mock_acu.call_args[0][1]
+            self.assertEqual({"transit1-sw1"}, set(s.switch_name for s in swcfgs))
+            for swcfg in swcfgs:
+                for iface in swcfg.ifaces:
+                    self.assertEqual({111}, set(iface.trunk_vlans))
+
+    def test_switchgroups(self):
+        # index
+        resp = self.app.get("/cc-fabric/switchgroups")
+        sgs = resp.json
+        self.assertEqual(7, len(sgs))
+        self.assertEqual("seagull", sgs[0]['name'])
+
+        # detail
+        resp = self.app.get("/cc-fabric/switchgroups/seagull")
+        sg = resp.json
+        self.assertEqual("seagull", sg['name'])
+
+    def test_switchgroup_sync(self):
+        with mock.patch.object(CCFabricSwitchAgentRPCClient, 'apply_config_update') as mock_acu:
+            resp = self.app.put("/cc-fabric/switchgroups/seagull/sync")
+            self.assertEqual(2, mock_acu.call_count)
+            expected = {
+                'seagull-sw1': {'sync_sent': True},
+                'seagull-sw2': {'sync_sent': True},
+            }
+            self.assertEqual(expected, resp.json)
+
+    def test_switchgroup_sync_infra_networks(self):
+        with mock.patch.object(CCFabricSwitchAgentRPCClient, 'apply_config_update') as mock_acu:
+            resp = self.app.put("/cc-fabric/switchgroups/seagull/sync_infra_networks")
+            self.assertEqual(2, mock_acu.call_count)
+            expected = {
+                'seagull-sw1': {'sync_sent': True},
+                'seagull-sw2': {'sync_sent': True},
+            }
+            self.assertEqual(expected, resp.json)

--- a/networking_ccloud/tests/unit/ml2/test_mech_driver.py
+++ b/networking_ccloud/tests/unit/ml2/test_mech_driver.py
@@ -504,7 +504,7 @@ class TestCCFabricMechanismDriverInterconnects(CCFabricMechanismDriverTestBase):
             mock_acu.assert_called()
 
             # check DB
-            interconnects = self.mech_driver.db.get_interconnects_for_network(self.context, net['id'])
+            interconnects = self.mech_driver.fabric_plugin.get_interconnects(self.context, net['id'])
             self.assertEqual(self._ic_devices, sorted([d.host for d in interconnects]))
 
             # check config
@@ -558,11 +558,11 @@ class TestCCFabricMechanismDriverInterconnects(CCFabricMechanismDriverTestBase):
             mock_acu.assert_called()
 
             # no BGWs
-            bgws = self.mech_driver.db.get_bgws_for_network(self.context, net['id'])
+            bgws = self.mech_driver.fabric_plugin.get_bgws_for_network(self.context, net['id'])
             self.assertEqual([], bgws)
 
             # only one transit, in AZ
-            transits = self.mech_driver.db.get_transits_for_network(self.context, net['id'])
+            transits = self.mech_driver.fabric_plugin.get_transits_for_network(self.context, net['id'])
             self.assertEqual(1, len(transits))
             self.assertEqual("qa-de-1a", transits[0].availability_zone)
 
@@ -578,11 +578,11 @@ class TestCCFabricMechanismDriverInterconnects(CCFabricMechanismDriverTestBase):
             mock_acu.assert_not_called()
 
             # no BGWs
-            bgws = self.mech_driver.db.get_bgws_for_network(self.context, net['id'])
+            bgws = self.mech_driver.fabric_plugin.get_bgws_for_network(self.context, net['id'])
             self.assertEqual([], bgws)
 
             # only one transit, in AZ
-            transits = self.mech_driver.db.get_transits_for_network(self.context, net['id'])
+            transits = self.mech_driver.fabric_plugin.get_transits_for_network(self.context, net['id'])
             self.assertEqual([], transits)
 
     def test_cannot_bind_port_with_special_device_binding_host(self):
@@ -609,7 +609,7 @@ class TestCCFabricMechanismDriverInterconnects(CCFabricMechanismDriverTestBase):
                 hosts = set()
                 for call in fake_method.call_args_list:
                     args, kwargs = call
-                    self.assertEqual((cc_const.CC_TRANSIT, events.AFTER_CREATE, self.mech_driver), args)
+                    self.assertEqual((cc_const.CC_TRANSIT, events.AFTER_CREATE, self.mech_driver.fabric_plugin), args)
                     payload = kwargs['payload']
                     self.assertEqual(net['id'], payload.metadata['network_id'])
                     hosts.add(payload.metadata['host'])

--- a/networking_ccloud/tools/agent_rpc_caller.py
+++ b/networking_ccloud/tools/agent_rpc_caller.py
@@ -12,6 +12,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from pprint import pprint
 import sys
 
 from neutron.common import config as common_config
@@ -59,7 +60,8 @@ def main():
 
     print(f"Doing RPC call {CONF.method}(*{CONF.args}) with topic {topic}")
     ctx = context.get_admin_context()
-    print("Result:", getattr(client, CONF.method)(ctx, *CONF.args))
+    print("Result:")
+    pprint(getattr(client, CONF.method)(ctx, *CONF.args))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
With this commit we can now inspect and sync networks, switches and
switchgroups.

Networks can't be listed (it would simply list all available network
ids), but can be shown by id - this will include some extra info by the
driver (binding hosts, interconnects). There are two extra methods
available: sync to sync the network (will be a config "merge") and
ensure_interconnecfts, which will allocate and configure interconnects
to said network. Both are available via HTTP PUT.

Switches can be listed and shown. Adding ?device_info=1 to the URL will
also fetch uptime and the current firmware version from the switch. Sync
is available, but will replace the config by fetching all physnets
scheduled onto this switch. InfraNetworks will be configured as well. To
configure only infranetworks sync_infra_networks is available.

SwitchGroup operations are implemented by searching for the given
switchgroup and then calling the SwitchesController for each switch in
the switchgroup. For operations on the switchgroup this means one RPC
call is done sequentially for each switch. This has some potential for
improvement, but for now this was the easiest way to implement it. When
this becomes a painpoint we can fix it.

"diff" is not yet implemented. It will be implemented together with
config fetching off of the switches.

References to the CCDbPlugin have been replaced with the FabricPlugin.
The FabricPlugin acts very much like the CCDbPlugin, but it adds some
extra non-db methods. This was done because I needed a place to put code
which can be accessed both by the Ml2MechanismDriver and the API, but I
still wanted to keep the CCDbPlugin mostly about DB methods.  The fabric
plugin will most likely be used by the config syncloop as well.