### PR TITLE
Add run() method to agent

### DIFF
--- a/networking_ccloud/ml2/agent/common/agent.py
+++ b/networking_ccloud/ml2/agent/common/agent.py
@@ -142,6 +142,9 @@ class CCFabricSwitchAgent(manager.Manager, cc_agent_api.CCFabricSwitchAgentAPI):
         if self.agent_state.pop('start_flag', None):
             self.run()
 
+    def run(self):
+        LOG.info("Run called after start")
+
     def get_switch_status(self, context, switches=None):
         """Get status for specified or all switches this agent manages
 


### PR DESCRIPTION
We copied part of the agent's _report_state() method out of neutron. The
code expects a run() method to call for actions to be done on first
agent start, but at the moment we don't have anything we would want to
call there. To allow us to fill this method later on (e.g. with a sync
loop) I just added this method with a simple log message. For future
use.