### PR TITLE
Explicitly list AZs in driver config

### DIFF
--- a/examples/cc-driver-config.yaml
+++ b/examples/cc-driver-config.yaml
@@ -2,6 +2,10 @@ global_config:
   asn_region: 65132
   default_vlan_ranges:
     - 2000:3750
+  availability_zones:
+    - name: qa-de-2a
+      suffix: a
+      number: 1
 
 hostgroups:
 - binding_hosts:

--- a/examples/cc-driver-config.yaml
+++ b/examples/cc-driver-config.yaml
@@ -6,6 +6,7 @@ global_config:
     - name: qa-de-2a
       suffix: a
       number: 1
+  vrfs: []
 
 hostgroups:
 - binding_hosts:

--- a/networking_ccloud/common/config/config_driver.py
+++ b/networking_ccloud/common/config/config_driver.py
@@ -378,6 +378,13 @@ class Hostgroup(pydantic.BaseModel):
         return False
 
 
+class VRF(pydantic.BaseModel):
+    name: str
+
+    # magic number we use for vni, rt import/export calculation
+    number: pydantic.conint(gt=0)
+
+
 class AvailabilityZone(pydantic.BaseModel):
     name: str
     suffix: str
@@ -396,6 +403,7 @@ class GlobalConfig(pydantic.BaseModel):
     asn_region: str
     default_vlan_ranges: List[str]
     availability_zones: List[AvailabilityZone]
+    vrfs: List[VRF]
 
     _normalize_asn = pydantic.validator('asn_region', allow_reuse=True)(validate_asn)
     _normalize_vlan_ranges = pydantic.validator('default_vlan_ranges',

--- a/networking_ccloud/tests/common/config_fixtures.py
+++ b/networking_ccloud/tests/common/config_fixtures.py
@@ -109,6 +109,7 @@ def make_interconnect(role, host, switch_base, handle_azs):
 def make_global_config(asn_region=65123, **kwargs):
     kwargs.setdefault("default_vlan_ranges", ["2000:3750"])
     kwargs.setdefault("availability_zones", [])
+    kwargs.setdefault("vrfs", [])
     return config_driver.GlobalConfig(asn_region=asn_region, **kwargs)
 
 

--- a/networking_ccloud/tests/common/config_fixtures.py
+++ b/networking_ccloud/tests/common/config_fixtures.py
@@ -108,13 +108,29 @@ def make_interconnect(role, host, switch_base, handle_azs):
 
 def make_global_config(asn_region=65123, **kwargs):
     kwargs.setdefault("default_vlan_ranges", ["2000:3750"])
+    kwargs.setdefault("availability_zones", [])
     return config_driver.GlobalConfig(asn_region=asn_region, **kwargs)
+
+
+def make_azs(names):
+    azs = []
+    for name in names:
+        az_num = ord(name[-1]) - ord('a') + 1
+        azs.append(config_driver.AvailabilityZone(name=name, suffix=name[-1], number=az_num))
+    return azs
+
+
+def make_azs_from_switchgroups(switchgroups):
+    if switchgroups is None:
+        return []
+
+    return make_azs(az for az in set(sg.availability_zone for sg in switchgroups))
 
 
 # whole config
 def make_config(switchgroups=None, hostgroups=None, global_config=None):
     if not global_config:
-        global_config = make_global_config()
+        global_config = make_global_config(availability_zones=make_azs_from_switchgroups(switchgroups))
 
     return config_driver.DriverConfig(
         switchgroups=switchgroups or [],

--- a/networking_ccloud/tests/unit/common/test_driver_config.py
+++ b/networking_ccloud/tests/unit/common/test_driver_config.py
@@ -116,13 +116,14 @@ class TestDriverConfigValidation(base.TestCase):
         self.assertRaisesRegex(ValueError, ".*needs to have a start that.*", config.GlobalConfig, asn_region=65000,
                                default_vlan_ranges=["456:123"], availability_zones=[])
 
-        config.GlobalConfig(asn_region=65000, default_vlan_ranges=["2000:3750"], availability_zones=[])
-        config.GlobalConfig(asn_region=65000, default_vlan_ranges=["2000:2000"], availability_zones=[])
-        config.GlobalConfig(asn_region=65000, default_vlan_ranges=["100:200", "500:600"], availability_zones=[])
+        config.GlobalConfig(asn_region=65000, default_vlan_ranges=["2000:3750"], availability_zones=[], vrfs=[])
+        config.GlobalConfig(asn_region=65000, default_vlan_ranges=["2000:2000"], availability_zones=[], vrfs=[])
+        config.GlobalConfig(asn_region=65000, default_vlan_ranges=["100:200", "500:600"], availability_zones=[],
+                            vrfs=[])
 
     def test_all_switchgroup_azs_need_to_exist(self):
         global_config = config.GlobalConfig(asn_region=65000, default_vlan_ranges=["2000:3750"],
-                                            availability_zones=cfix.make_azs(["qa-de-1a"]))
+                                            availability_zones=cfix.make_azs(["qa-de-1a"]), vrfs=[])
         switchgroups = [
             cfix.make_switchgroup("seagull", availability_zone="qa-de-1a"),
             cfix.make_switchgroup("crow", availability_zone="qa-de-1b"),


### PR DESCRIPTION
In the future each AZ will need a number and a suffix. As we don't want
to require a specific AZ format, we allow this to be configured. This
also allows us a somewhat easier AZ handling, as we don't need to
iterate over all switchgroups and could also define AZs for which we
don't have a switchgroup.

Adaption of the config generator for this is not part of this commit.