### PR TITLE
Explicitly add RTs to agent message format

### DIFF
--- a/networking_ccloud/common/config/config_driver.py
+++ b/networking_ccloud/common/config/config_driver.py
@@ -100,9 +100,6 @@ class Switch(pydantic.BaseModel):
 
         return v
 
-    def get_rt(self, vni):
-        return f"{self.bgp_source_ip}:{vni}"
-
 
 class HostgroupRole(str, Enum):
     transit = cc_const.DEVICE_TYPE_TRANSIT

--- a/networking_ccloud/ml2/agent/common/agent.py
+++ b/networking_ccloud/ml2/agent/common/agent.py
@@ -162,6 +162,18 @@ class CCFabricSwitchAgent(manager.Manager, cc_agent_api.CCFabricSwitchAgentAPI):
                 result['switches'][switch.name] = dict(reachable=False, error=str(e))
         return result
 
+    def get_switch_config(self, context, switches):
+        result = {'switches': {}}
+        for switch in self._switches:
+            if switches and switch.name not in switches:
+                continue
+            try:
+                config = switch.get_config().dict(exclude_unset=True, exclude_defaults=True)
+                result['switches'][switch.name] = dict(reachable=True, config=config)
+            except cc_exc.SwitchConnectionError as e:
+                result['switches'][switch.name] = dict(reachable=False, error=str(e))
+        return result
+
     def apply_config_update(self, context, config):
         result = {}
         for update in config:

--- a/networking_ccloud/ml2/agent/common/api.py
+++ b/networking_ccloud/ml2/agent/common/api.py
@@ -41,6 +41,9 @@ class CCFabricSwitchAgentAPI:
     def apply_config_update(self, context, config):
         raise NotImplementedError
 
+    def get_switch_config(self, context, switches):
+        raise NotImplementedError
+
 
 class CCFabricSwitchAgentRPCClient:
     """Client side RPC interface definition for talking to switching agents
@@ -77,3 +80,7 @@ class CCFabricSwitchAgentRPCClient:
         meth_name = "call" if synchronous else "cast"
         meth = getattr(cctxt, meth_name)
         return meth(context, 'apply_config_update', config=[c.dict() for c in config])
+
+    def get_switch_config(self, context, switches=None):
+        cctxt = self.client.prepare()
+        return cctxt.call(context, 'get_switch_config', switches=switches)

--- a/networking_ccloud/ml2/agent/common/switch.py
+++ b/networking_ccloud/ml2/agent/common/switch.py
@@ -52,5 +52,8 @@ class SwitchBase(abc.ABC):
     def get_switch_status(self):
         raise NotImplementedError
 
+    def get_config(self):
+        raise NotImplementedError
+
     def apply_config_update(self, config):
         raise NotImplementedError

--- a/networking_ccloud/tests/unit/extensions/test_extensions.py
+++ b/networking_ccloud/tests/unit/extensions/test_extensions.py
@@ -264,6 +264,22 @@ class TestNetworkExtension(test_segment.SegmentTestCase, base.PortBindingHelper)
                 for iface in swcfg.ifaces:
                     self.assertEqual({111}, set(iface.trunk_vlans))
 
+    def test_switch_get_config(self):
+        with mock.patch.object(CCFabricSwitchAgentRPCClient, 'get_switch_config') as mock_gsc:
+            mock_gsc.return_value = {
+                'switches': {
+                    'seagull-sw1': {'reachable': True, 'config': {'operation': 'add', 'switch_name': 'seagull-sw1'}},
+                },
+            }
+            resp = self.app.get("/cc-fabric/switches/seagull-sw1/config")
+            expected = {
+                'reachable': True,
+                'config': {
+                    'switch_name': 'seagull-sw1',
+                },
+            }
+            self.assertEqual(expected, resp.json)
+
     def test_switchgroups(self):
         # index
         resp = self.app.get("/cc-fabric/switchgroups")
@@ -319,5 +335,30 @@ class TestNetworkExtension(test_segment.SegmentTestCase, base.PortBindingHelper)
             expected = {
                 'seagull-sw1': {'sync_sent': True},
                 'seagull-sw2': {'sync_sent': True},
+            }
+            self.assertEqual(expected, resp.json)
+
+    def test_switchgroup_get_config(self):
+        with mock.patch.object(CCFabricSwitchAgentRPCClient, 'get_switch_config') as mock_gsc:
+            mock_gsc.return_value = {
+                'switches': {
+                    'seagull-sw1': {'reachable': True, 'config': {'operation': 'add', 'switch_name': 'seagull-sw1'}},
+                    'seagull-sw2': {'reachable': True, 'config': {'operation': 'add', 'switch_name': 'seagull-sw2'}},
+                },
+            }
+            resp = self.app.get("/cc-fabric/switchgroups/seagull/config")
+            expected = {
+                'seagull-sw1': {
+                    'reachable': True,
+                    'config': {
+                        'switch_name': 'seagull-sw1',
+                    },
+                },
+                'seagull-sw2': {
+                    'reachable': True,
+                    'config': {
+                        'switch_name': 'seagull-sw2',
+                    },
+                },
             }
             self.assertEqual(expected, resp.json)

--- a/networking_ccloud/tests/unit/extensions/test_extensions.py
+++ b/networking_ccloud/tests/unit/extensions/test_extensions.py
@@ -306,7 +306,6 @@ class TestNetworkExtension(test_segment.SegmentTestCase, base.PortBindingHelper)
             resp = self.app.get("/cc-fabric/switchgroups?device_info=1")
             sgs = resp.json
             self.assertEqual(7, len(sgs))
-            print(sgs[0])
             self.assertTrue("seagull", sgs[0]['members'][0]['device_info']['reachable'])
             self.assertEqual(14, mock_gss.call_count)
             mock_gss.reset_mock()

--- a/networking_ccloud/tests/unit/ml2/agent/common/test_messages.py
+++ b/networking_ccloud/tests/unit/ml2/agent/common/test_messages.py
@@ -51,9 +51,20 @@ class TestSwitchConfigUpdate(base.TestCase):
 
         # bgp
         bgp = agent_msg.BGP(asn=65000, asn_region=65123)
-        bgp.add_vlan("foo", 23, 42)
-        bgp.add_vlan("foo", 23, 42)
+        bgp.add_vlan(23, 42)
+        bgp.add_vlan(23, 42)
         self.assertEqual(1, len(bgp.vlans))
-        bgp.add_vlan("foo", 13, 37)
-        bgp.add_vlan("bar", 23, 42)
+        bgp.add_vlan(13, 37)
+        bgp.add_vlan(23, 42)
+        bgp.add_vlan(100, 100)
         self.assertEqual(3, len(bgp.vlans))
+
+    def test_rt_validation(self):
+        # int conversion
+        self.assertEqual("65130:10091", agent_msg.validate_route_target("842681173419883"))
+        self.assertEqual("65000.1337:6667", agent_msg.validate_route_target(144957310991145483))
+        self.assertEqual("23.23.23.23:4242", agent_msg.validate_route_target("72645931930423442"))
+
+        # format fixing
+        self.assertEqual("65130.23:1234", agent_msg.validate_route_target("4268359703:1234"))
+        self.assertEqual("123:123", agent_msg.validate_route_target("123:123"))

--- a/networking_ccloud/tests/unit/ml2/agent/eos/test_config_updates.py
+++ b/networking_ccloud/tests/unit/ml2/agent/eos/test_config_updates.py
@@ -101,7 +101,7 @@ class TestEOSConfigUpdates(base.TestCase):
 
         # bgp stuff / vlans
         cu.bgp = messages.BGP(asn="65000", asn_region="65123")
-        cu.bgp.add_vlan("1.1.1.1:232323", 1000, 232323)
+        cu.bgp.add_vlan(1000, 232323)
 
         # interfaces
         iface1 = messages.IfaceConfig(name="Port-channel23", portchannel_id=23, native_vlan=1000,
@@ -169,7 +169,7 @@ class TestEOSConfigUpdates(base.TestCase):
 
         # bgp stuff / vlans
         cu.bgp = messages.BGP(asn="65000", asn_region="65123")
-        cu.bgp.add_vlan("1.1.1.1:232323", 1000, 232323)
+        cu.bgp.add_vlan(1000, 232323)
 
         # interfaces
         iface1 = messages.IfaceConfig(name="Port-channel23", portchannel_id=23, native_vlan=1000,
@@ -360,7 +360,7 @@ class TestEOSConfigUpdates(base.TestCase):
         cu = messages.SwitchConfigUpdate(switch_name="seagull-sw1", operation=messages.OperationEnum.replace)
         # bgp vlans
         cu.bgp = messages.BGP(asn="65000", asn_region="65123")
-        cu.bgp.add_vlan("1.1.1.1:232323", 1000, 232323)
+        cu.bgp.add_vlan(1000, 232323)
 
         self.switch.apply_config_update(cu)
         self.switch._api.execute.assert_called_with(expected_config, format='json')
@@ -371,8 +371,10 @@ class TestEOSConfigUpdates(base.TestCase):
             'router bgp 65000',
             'vlan 1000',
             'rd evpn domain all 65000:232323',
-            'route-target both 65123:232323',
-            'route-target import export evpn domain remote 65123:232323',
+            'route-target import 65123:232323',
+            'route-target export 65123:232323',
+            'route-target import evpn domain remote 65123:232323',
+            'route-target export evpn domain remote 65123:232323',
             'redistribute learned',
             'exit',
             'exit',
@@ -382,7 +384,7 @@ class TestEOSConfigUpdates(base.TestCase):
         cu = messages.SwitchConfigUpdate(switch_name="seagull-sw1", operation=messages.OperationEnum.add)
         # bgp vlans
         cu.bgp = messages.BGP(asn="65000", asn_region="65123")
-        cu.bgp.add_vlan("1.1.1.1:232323", 1000, 232323, bgw_mode=True)
+        cu.bgp.add_vlan(1000, 232323, bgw_mode=True)
 
         self.switch.apply_config_update(cu)
         self.switch._api.execute.assert_called_with(expected_config, format='json')

--- a/networking_ccloud/tests/unit/ml2/test_mech_driver.py
+++ b/networking_ccloud/tests/unit/ml2/test_mech_driver.py
@@ -556,7 +556,7 @@ class TestCCFabricMechanismDriverInterconnects(CCFabricMechanismDriverTestBase):
                 self.assertEqual(1, len(s.vlans), "Only one VLAN config expected")
                 self.assertEqual(1, len(s.bgp.vlans))
                 if s.switch_name.startswith("bgw"):
-                    self.assertTrue(s.bgp.vlans[0].bgw_mode)
+                    self.assertTrue(s.bgp.vlans[0].rd_evpn_domain_all)
                 else:
                     # transit
                     for iface in s.ifaces:


### PR DESCRIPTION
We now put the Route Targets that should be exported/imported directly
into the agent message / SwitchConfig format. This means that we'll have
less business logic inside the agent and more in the neutron-server part
of the driver (which is a good thing, as we will have multiple agents
and therefore will not need to duplicate business logic). It will also
help when we implement the config diff functionality, as we can then
just fill the SwitchConfig object with what's on the switch and diff it
with the "should" version from OpenStack.