### PR TITLE
Pull InfraNetworks from netbox and change driver config

### DIFF
--- a/networking_ccloud/common/config/config_driver.py
+++ b/networking_ccloud/common/config/config_driver.py
@@ -431,6 +431,24 @@ class GlobalConfig(pydantic.BaseModel):
     _normalize_vlan_ranges = pydantic.validator('default_vlan_ranges',
                                                 each_item=True, allow_reuse=True)(validate_vlan_ranges)
 
+    @pydantic.validator('vrfs')
+    def check_vrf_name_unique(cls, values):
+        names = set()
+        for vrf in values:
+            if vrf.name in names:
+                raise ValueError(f'VRF {vrf.name} is duplicated')
+            names.add(vrf.name)
+        return values
+
+    @pydantic.validator('vrfs')
+    def check_vrf_number_unique(cls, values):
+        nums = set()
+        for vrf in values:
+            if vrf.number in nums:
+                raise ValueError(f'VRF id {vrf.number} is duplicated on VRF {vrf.name}')
+            nums.add(vrf.number)
+        return values
+
 
 class DriverConfig(pydantic.BaseModel):
     global_config: GlobalConfig

--- a/networking_ccloud/tests/unit/common/test_driver_config.py
+++ b/networking_ccloud/tests/unit/common/test_driver_config.py
@@ -166,6 +166,19 @@ class TestDriverConfigValidation(base.TestCase):
                                config.DriverConfig, switchgroups=[switchgroup], hostgroups=hostgroups,
                                global_config=global_config)
 
+    def test_duplicate_vrf_name(self):
+        vrfs = cfix.make_vrfs(['ROUTE-ME', 'ROUTE-ME'])
+
+        self.assertRaisesRegex(ValueError, "VRF ROUTE-ME is duplicated",
+                               cfix.make_global_config, cfix.make_azs(['monster-az-a']), vrfs=vrfs)
+
+    def test_duplicate_vrf_id(self):
+        vrfs = cfix.make_vrfs(['ROUTE-ME', 'SWITCH-ME'])
+        vrfs[0].number = vrfs[1].number
+
+        self.assertRaisesRegex(ValueError, "VRF id 2 is duplicated on VRF SWITCH-ME",
+                               cfix.make_global_config, cfix.make_azs(['monster-az-a']), vrfs=vrfs)
+
 
 class TestDriverConfig(base.TestCase):
     def setUp(self):

--- a/networking_ccloud/tests/unit/common/test_driver_config.py
+++ b/networking_ccloud/tests/unit/common/test_driver_config.py
@@ -131,6 +131,26 @@ class TestDriverConfigValidation(base.TestCase):
         self.assertRaisesRegex(ValueError, ".*SwitchGroup crow has invalid az qa-de-1b.* options are.*qa-de-1a.*",
                                cfix.make_config, switchgroups=switchgroups, hostgroups=[], global_config=global_config)
 
+    def test_l3_infra_network_requires_vrf(self):
+        exc = 'If network is given a VRF must be set too'
+        self.assertRaisesRegex(ValueError, exc, config.InfraNetwork, name='where-did-the-vrf-go', vlan=1202,
+                               networks=['1.2.0.2/24'], vni=1202)
+
+    def test_infra_network_dhcp_requires_network(self):
+        exc = 'If dhcp_relays is given a network must be present too'
+        self.assertRaisesRegex(ValueError, exc, config.InfraNetwork, name='no-network-lot-cry', vlan=1202,
+                               vni=1202, vrf='DHCP-VRF', dhcp_relays=['1.2.3.4'])
+
+    def test_infra_network_dhcp_not_in_network(self):
+        exc = 'dhcp_relay .* is contained in network'
+        self.assertRaisesRegex(ValueError, exc, config.InfraNetwork, name='why-relay-me', vlan=1202,
+                               vni=1202, vrf='DHCP-VRF', dhcp_relays=['1.2.3.4'], networks=['1.2.3.5/24'])
+
+    def test_l3_infra_network_needs_host_bits(self):
+        exc = 'Network .* is supposed to be used as gateway and hence needs hosts bits set'
+        self.assertRaisesRegex(ValueError, exc, config.InfraNetwork, name='i-am-a-network-address', vlan=1202,
+                               vni=1202, vrf='DHCP-VRF', networks=['1.2.3.0/24'])
+
 
 class TestDriverConfig(base.TestCase):
     def setUp(self):

--- a/networking_ccloud/tests/unit/extensions/test_extensions.py
+++ b/networking_ccloud/tests/unit/extensions/test_extensions.py
@@ -83,9 +83,8 @@ class TestNetworkExtension(test_segment.SegmentTestCase, base.PortBindingHelper)
                                   switch_vars=dict(platform=cc_const.PLATFORM_EOS)),
         ]
         seagull_infra_nets = [
-            # FIXME: networks entry needs to be a CIDR, but bug in config doesn't allow that
-            InfraNetwork(name="infra_net_l3", vlan=23, networks=["10.23.42.1"], vni=6667),
-            InfraNetwork(name="infra_net_vlan", vlan=42),
+            InfraNetwork(name="infra_net_l3", vlan=23, networks=["10.23.42.1/24"], vrf='PRIVATE-VRF', vni=6667),
+            InfraNetwork(name="infra_net_vlan", vlan=42, vni=14),
         ]
         hg_seagull = cfix.make_metagroup("seagull", meta_kwargs={'infra_networks': seagull_infra_nets})
         hg_crow = cfix.make_metagroup("crow")

--- a/networking_ccloud/tools/netbox_config_gen.py
+++ b/networking_ccloud/tools/netbox_config_gen.py
@@ -126,7 +126,7 @@ class ConfigGenerator:
     def get_cloud_vrfs(self) -> List[conf.VRF]:
         vrfs = list()
         search_strings = ['CC-CLOUD', 'CC-MGMT']
-        nb_return = chain(*(self.netbox.ipam.vrfs.filter(q=x, tenant=self.connection_tenants) for x in search_strings))
+        nb_return = chain(*(self.netbox.ipam.vrfs.filter(q=x, tenant=self.tenants) for x in search_strings))
         for vrf in nb_return:
             rd_suffix = int(vrf.rd[vrf.rd.find(':') + 1:])
             vrfs.append(conf.VRF(name=vrf.name, number=rd_suffix))  # type: ignore


### PR DESCRIPTION
Pulling InfraNetworks from netbox using vlans assigned to the server
facing ports, as well as the SVIs modelled on the TORs for the anycast
gateteway.
Also made VNI an mandatory field, as we potentially want to stretch
every VLAN over TOR borders.
VRF is also mandtory if the network is L3 enabled.