### PR TITLE
Remove E241 from tox pep8 ignore list

### DIFF
--- a/networking_ccloud/common/config/config_driver.py
+++ b/networking_ccloud/common/config/config_driver.py
@@ -574,7 +574,7 @@ class DriverConfig(pydantic.BaseModel):
             return values
         if 'hostgroups' not in values:
             return values
-        global_config:  GlobalConfig = values['global_config']
+        global_config: GlobalConfig = values['global_config']
         hgs: List[Hostgroup] = values['hostgroups']
         vrf_names = set(x.name for x in global_config.vrfs)
         for hg in hgs:

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,6 @@ commands = oslo_debug_helper {posargs}
 
 show-source = True
 max-line-length = 120
-ignore = E123,E125,E241,E402,E741,W503,W504,H301
+ignore = E123,E125,E402,E741,W503,W504,H301
 builtins = _
 exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,build


### PR DESCRIPTION
E241 - multiple spaces after ','; this one should not have landed on the
ignore list.