### PR TITLE
Add aggregate attribute to InfraNetworks

### DIFF
--- a/networking_ccloud/common/config/config_driver.py
+++ b/networking_ccloud/common/config/config_driver.py
@@ -271,7 +271,7 @@ class Hostgroup(pydantic.BaseModel):
     handle_availability_zones: List[str] = None
 
     # infra networks attached to hostgroup
-    infra_networks: List[InfraNetwork] = None
+    infra_networks: List[InfraNetwork] = []
 
     class Config:
         use_enum_values = True

--- a/networking_ccloud/tests/unit/common/test_driver_config.py
+++ b/networking_ccloud/tests/unit/common/test_driver_config.py
@@ -151,6 +151,25 @@ class TestDriverConfigValidation(base.TestCase):
         self.assertRaisesRegex(ValueError, exc, config.InfraNetwork, name='i-am-a-network-address', vlan=1202,
                                vni=1202, vrf='DHCP-VRF', networks=['1.2.3.0/24'])
 
+    def test_l3_infra_network_aggregate_needs_networks(self):
+        exc = 'There are more aggregates than networks'
+        self.assertRaisesRegex(ValueError, exc, config.InfraNetwork, name='i-miss-my-network', vlan=1202,
+                               vni=1202, vrf='ROUTE-ME', aggregates=['1.2.3.0/24'])
+
+    def test_l3_infra_network_with_aggregate(self):
+        config.InfraNetwork(name='aggregate-me-if-you-can', vlan=1202, vni=1202, vrf='ROUTE-ME',
+                            aggregates=['1.2.3.0/24'], networks=['1.2.3.1/25'])
+
+    def test_l3_infra_network_network_not_contained_in_aggregate(self):
+        exc = 'Aggregate .* is not a supernet of any network in networks'
+        self.assertRaisesRegex(ValueError, exc, config.InfraNetwork, name='aggregate-me-if-you-can', vlan=1202,
+                               vni=1202, vrf='ROUTE-ME', aggregates=['1.2.3.0/24'], networks=['1.2.10.1/24'])
+
+    def test_l3_infra_network_is_aggregate(self):
+        exc = 'Aggregate .* is equal to one of the networks'
+        self.assertRaisesRegex(ValueError, exc, config.InfraNetwork, name='aggregate-me-if-you-can', vlan=1202,
+                               vni=1202, vrf='ROUTE-ME', aggregates=['1.2.3.0/24'], networks=['1.2.3.1/24'])
+
     def test_infra_network_vrf_presence(self):
         vrfs = cfix.make_vrfs(['ROUTE-ME', 'SWITCH-ME'])
         infra_net_ok = config.InfraNetwork(name='l3-correct-vrf', vlan=1202, vni=1202, vrf='ROUTE-ME')

--- a/networking_ccloud/tools/netbox_config_gen.py
+++ b/networking_ccloud/tools/netbox_config_gen.py
@@ -528,7 +528,7 @@ class ConfigGenerator:
             for infra_net in member.infra_networks:
                 if infra_net not in minimum_common_infra_nets:
                     remaining_infra_nets.append(infra_net)
-            member.infra_networks = remaining_infra_nets if remaining_infra_nets else None  # type: ignore
+            member.infra_networks = remaining_infra_nets
         metagroup.infra_networks = sorted(minimum_common_infra_nets, key=attrgetter('vlan'))
 
     def generate_config(self):


### PR DESCRIPTION
We want to aggregate as much as possible. L3 enabled InfraNetworks for
us are usually supernetted on a TOR level to a single network. We could
calculate the aggregate if all networks in all InfraNetworks associated
with a hostgroup would result in a full supernet but they do not.

In order to not hardcode the aggregate calculation logic into the code
and stay flexible, we feed an optional aggregate list for each
InfraNetwork. This indicates which aggregate the InfraNetwork will be
part of.

In turn, this aggregation list is for us generated out of the netbox
parent prefix.