### PR TITLE
Reorganize read/write switchconfig methods into smaller methods

### DIFF
--- a/networking_ccloud/tests/unit/ml2/agent/eos/test_switch.py
+++ b/networking_ccloud/tests/unit/ml2/agent/eos/test_switch.py
@@ -245,7 +245,7 @@ class TestEOSConfigUpdates(base.TestCase):
         def execute(cmd, format='json'):
             if cmd == "show vlan":
                 return {'result': [
-                    {'vlans': {str(v): {} for v in [1, 100, 1000, 1003, 4093, 4094]}},
+                    {'vlans': {str(v): {'name': f'vlan-{v}'} for v in [1, 100, 1000, 1003, 4093]}},
                 ]}
             return mock.DEFAULT
         self.switch._api.execute.side_effect = execute

--- a/networking_ccloud/tests/unit/ml2/agent/eos/test_switch.py
+++ b/networking_ccloud/tests/unit/ml2/agent/eos/test_switch.py
@@ -541,7 +541,9 @@ class TestEOSSwitch(base.TestCase):
         iface = messages.IfaceConfig(name="Ethernet1/1")
         iface.add_vlan_translation(2000, 3001)
         cu.add_iface(iface)
+        cu.sort()
 
         config = self.switch.get_config()
+        config.sort()
         self.assertEqual(cu.dict(exclude_unset=True, exclude_defaults=True),
                          config.dict(exclude_unset=True, exclude_defaults=True))


### PR DESCRIPTION
Instead of reading and writing all configuration in on large method such
as `get_config` or `_make_config_from_update` we keep these methods but
move the generation of the config entities into smaller methods. Each
methods generates either configuration commands and reads config for a
singular top-level entity. This keeps the methods smaller and more
modular. We may also think about moving the top-level methods into the
base class later.