### PR TITLE
Use switchgroup id as RD for BGP vlans

### DIFF
--- a/examples/cc-driver-config.yaml
+++ b/examples/cc-driver-config.yaml
@@ -18,6 +18,7 @@ hostgroups:
     switch: qa-de-3-sw1111b-bb206
 switchgroups:
 - asn: '65132.1111'
+  group_id: 1111
   availability_zone: qa-de-2a
   members:
   - bgp_source_ip: 1.1.11.1

--- a/networking_ccloud/common/config/config_driver.py
+++ b/networking_ccloud/common/config/config_driver.py
@@ -123,6 +123,7 @@ class SwitchGroup(pydantic.BaseModel):
     # calculated from member-hostnames
     vtep_ip: str
     asn: str
+    group_id: pydantic.conint(ge=0, lt=2 ** 16)
 
     override_vlan_pool: str = None
     vlan_ranges: List[str] = None
@@ -544,6 +545,17 @@ class DriverConfig(pydantic.BaseModel):
                     raise ValueError(f"Iface {sp.switch}/{sp.name} is bound two times, "
                                      f"once by {hg_name} and once by {ifaces[iface]}")
                 ifaces[iface] = hg_name
+
+        return v
+
+    @pydantic.validator('switchgroups')
+    def ensure_switchgroup_id_unique(cls, v):
+        group_ids = {}
+        for sg in v:
+            if sg.group_id in group_ids:
+                raise ValueError(f"SwitchGroup {sg.name} has group id {sg.group_id}, which is already in use "
+                                 f"by SwitchGroup {group_ids[sg.group_id]}")
+            group_ids[sg.group_id] = sg.name
 
         return v
 

--- a/networking_ccloud/tests/common/config_fixtures.py
+++ b/networking_ccloud/tests/common/config_fixtures.py
@@ -35,12 +35,20 @@ def make_switch(name, platform="test", **kwargs):
     return config_driver.Switch(**switch_vars)
 
 
+_LAST_AUTO_GROUP_ID = 0
+
+
 def make_switchgroup(name, members=None, switch_vars=None, availability_zone=DEFAULT_AZ, **kwargs):
     switchgroup_vars = dict(
         name=name, asn=65100, availability_zone=availability_zone, role="vpod",
         vtep_ip="1.1.1.3",  # FIXME: derive IPs from somewhere
     )
     switchgroup_vars.update(kwargs)
+
+    if 'group_id' not in kwargs:
+        global _LAST_AUTO_GROUP_ID
+        _LAST_AUTO_GROUP_ID += 1
+        switchgroup_vars['group_id'] = _LAST_AUTO_GROUP_ID
 
     if switch_vars is None:
         switch_vars = None

--- a/networking_ccloud/tests/unit/common/test_driver_config.py
+++ b/networking_ccloud/tests/unit/common/test_driver_config.py
@@ -28,11 +28,19 @@ class TestDriverConfigValidation(base.TestCase):
         sw1 = self.make_switch("sw1")
         sw2 = self.make_switch("sw2")
         sw3 = self.make_switch("sw3")
-        sg_args = dict(name="foo", availability_zone="qa-de-1a", role="vpod", vtep_ip="1.1.1.1", asn=65001)
+        sg_args = dict(name="foo", availability_zone="qa-de-1a", role="vpod", vtep_ip="1.1.1.1", asn=65001, group_id=1)
 
         self.assertRaises(ValueError, config.SwitchGroup, members=[sw1], **sg_args)
         self.assertRaises(ValueError, config.SwitchGroup, members=[sw1, sw2, sw3], **sg_args)
         config.SwitchGroup(members=[sw1, sw2], **sg_args)
+
+    def test_switchgroup_group_ids_uniq(self):
+        gc = cfix.make_global_config()
+        sg1 = cfix.make_switchgroup("seagull", group_id=1000)
+        sg2 = cfix.make_switchgroup("tern", group_id=1000)
+
+        self.assertRaisesRegex(ValueError, ".*already in use",
+                               config.DriverConfig, global_config=gc, switchgroups=[sg1, sg2], hostgroups=[])
 
     def test_switchport_lacp_attr_validation(self):
         defargs = {'switch': 'sw-seagull', 'name': 'e1/1/1/1'}

--- a/networking_ccloud/tests/unit/ml2/agent/common/test_messages.py
+++ b/networking_ccloud/tests/unit/ml2/agent/common/test_messages.py
@@ -50,7 +50,7 @@ class TestSwitchConfigUpdate(base.TestCase):
         self.assertEqual(2, len(iface.vlan_translations))
 
         # bgp
-        bgp = agent_msg.BGP(asn=65000, asn_region=65123)
+        bgp = agent_msg.BGP(asn=65000, asn_region=65123, switchgroup_id=1000)
         bgp.add_vlan(23, 42)
         bgp.add_vlan(23, 42)
         self.assertEqual(1, len(bgp.vlans))

--- a/networking_ccloud/tests/unit/ml2/agent/eos/test_switch.py
+++ b/networking_ccloud/tests/unit/ml2/agent/eos/test_switch.py
@@ -64,7 +64,7 @@ class TestEOSConfigUpdates(base.TestCase):
              {'vlan-to-vni': [{'vlan': 1001, 'vni': 424242}]}),
             ('arista/eos/arista-exp-eos-evpn:evpn/evpn-instances',
              {'evpn-instance': [{'config': {'name': '1000',
-                                            'route-distinguisher': '65000:232323',
+                                            'route-distinguisher': '4223:232323',
                                             'redistribute': ['LEARNED']},
                                  'name': '1000',
                                  'route-target': {'config': {'export': ['65123:232323'],
@@ -142,7 +142,7 @@ class TestEOSConfigUpdates(base.TestCase):
         cu.add_vxlan_map(424242, 1001)
 
         # bgp stuff / vlans
-        cu.bgp = messages.BGP(asn="65000", asn_region="65123")
+        cu.bgp = messages.BGP(asn="65000", asn_region="65123", switchgroup_id=4223)
         cu.bgp.add_vlan(1000, 232323)
 
         # interfaces
@@ -246,7 +246,7 @@ class TestEOSConfigUpdates(base.TestCase):
         cu.add_vxlan_map(343434, 1337)
 
         # bgp stuff / vlans
-        cu.bgp = messages.BGP(asn="65000", asn_region="65123")
+        cu.bgp = messages.BGP(asn="65000", asn_region="65123", switchgroup_id=4223)
         cu.bgp.add_vlan(1000, 232323)
 
         # interfaces
@@ -450,7 +450,7 @@ class TestEOSConfigUpdates(base.TestCase):
         expected_config = {
             'replace': [('arista/eos/arista-exp-eos-evpn:evpn/evpn-instances',
                          {'evpn-instance': [{'config': {'name': '1000',
-                                                        'route-distinguisher': '65000:232323',
+                                                        'route-distinguisher': '4223:232323',
                                                         'redistribute': ['LEARNED']},
                                              'name': '1000',
                                              'route-target': {'config': {'export': ['65123:232323'],
@@ -463,7 +463,7 @@ class TestEOSConfigUpdates(base.TestCase):
 
         cu = messages.SwitchConfigUpdate(switch_name="seagull-sw1", operation=messages.OperationEnum.replace)
         # bgp vlans
-        cu.bgp = messages.BGP(asn="65000", asn_region="65123")
+        cu.bgp = messages.BGP(asn="65000", asn_region="65123", switchgroup_id=4223)
         cu.bgp.add_vlan(1000, 232323)
 
         self.switch.apply_config_update(cu)
@@ -474,7 +474,7 @@ class TestEOSConfigUpdates(base.TestCase):
             'update': [
                 ('cli:', 'router bgp 65000'),
                 ('cli:', 'vlan 1000'),
-                ('cli:', 'rd evpn domain all 65000:232323'),
+                ('cli:', 'rd evpn domain all 4223:232323'),
                 ('cli:', 'route-target import evpn domain remote 65123:232323'),
                 ('cli:', 'route-target export evpn domain remote 65123:232323'),
                 ('cli:', 'exit'),
@@ -495,7 +495,7 @@ class TestEOSConfigUpdates(base.TestCase):
 
         cu = messages.SwitchConfigUpdate(switch_name="seagull-sw1", operation=messages.OperationEnum.add)
         # bgp vlans
-        cu.bgp = messages.BGP(asn="65000", asn_region="65123")
+        cu.bgp = messages.BGP(asn="65000", asn_region="65123", switchgroup_id=4223)
         cu.bgp.add_vlan(1000, 232323, bgw_mode=True)
 
         self.switch.apply_config_update(cu)
@@ -529,7 +529,7 @@ class TestEOSSwitch(base.TestCase):
                 return {
                     'arista-exp-eos-evpn:evpn-instance': [
                         {'config': {'name': '2000',
-                                    'route-distinguisher': '65130.4113:10091'},
+                                    'route-distinguisher': '4223:10091'},
                          'route-target': {'config': {'export': ['65130:10091'], 'import': ['65130:10091']}},
                          'name': "2000"}
                     ]}
@@ -566,8 +566,9 @@ class TestEOSSwitch(base.TestCase):
         cu = messages.SwitchConfigUpdate(switch_name="seagull-sw1", operation=messages.OperationEnum.add)
         cu.add_vlan(2121, "b226a569-e0ed-4d24-b943-c7183288")
         cu.add_vxlan_map(31337, 2121)
-        cu.bgp = messages.BGP(asn="65130.4113", asn_region=65130)
+        cu.bgp = messages.BGP(asn="65130.4113", asn_region=65130, switchgroup_id=4223)
         cu.bgp.add_vlan(2000, 10091, bgw_mode=False)
+        cu.bgp.switchgroup_id = None  # not needed for comparison (not fetched from switch)
         iface = messages.IfaceConfig(name="Port-Channel109", members=["Ethernet9/1"],
                                      trunk_vlans=[2000, 2001, 2002], native_vlan=2121, portchannel_id=109)
         cu.add_iface(iface)

--- a/networking_ccloud/tools/netbox_config_gen.py
+++ b/networking_ccloud/tools/netbox_config_gen.py
@@ -350,7 +350,7 @@ class ConfigGenerator:
             sg_name = self.get_switchgroup_name(sg_attributes['pod_role'], numbered_resources['switchgroup_id'],
                                                 numbered_resources['seq_no'])
             switchgroup = conf.SwitchGroup(name=sg_name, members=members, availability_zone=sg_attributes['az'],
-                                           vtep_ip=l3_data['loopback1'], asn=l3_data['asn'])
+                                           vtep_ip=l3_data['loopback1'], asn=l3_data['asn'], group_id=switchgroup_id)
             switchgroups.append(switchgroup)
         return switchgroups
 


### PR DESCRIPTION
The BGP class of agent messages now carries a `switchgroup_id`. This
attribute is used by add_vlan() (and later add_vrf()) to generate the RD
for each BGP vlan stanza. It will not be filled when pulling config from
a switch and will probably need to be deleted when comparing config.

We also now change the RD, as just implied. The RD of BGP vlans is now
in the format of "{switchgroup_id}:{vni}", as the old format (prepending
the region asn in the format of "{region_asn}.{switchgroup_id}:{vni}"
was not available with Arista GNMI - they just break / can't parse these
Type 2 RDs. So, this is the way it shall be now.