### PR TITLE
Transport vlans as compressed strings

### DIFF
--- a/networking_ccloud/ml2/agent/eos/switch.py
+++ b/networking_ccloud/ml2/agent/eos/switch.py
@@ -48,7 +48,7 @@ class EOSGNMIClient:
         IFACES = "interfaces"
         IFACE = "interfaces/interface[name={iface}]"
         IFACE_ETH = "interfaces/interface[name={iface}]/ethernet"
-        IFACE_VLANS = "interfaces/interface[name={iface}]/ethernet/switched-vlan"
+        IFACE_VTRUNKS = "interfaces/interface[name={iface}]/ethernet/switched-vlan/config/trunk-vlans"
         IFACE_NATIVE_VLAN = "interfaces/interface[name={iface}]/ethernet/switched-vlan/config/native-vlan"
         IFACE_VTRANS = "interfaces/interface[name={iface}]/ethernet/switched-vlan/vlan-translation"
         IFACE_VTRANS_EGRESS = ("interfaces/interface[name={iface}]/ethernet/switched-vlan/vlan-translation/"
@@ -56,7 +56,7 @@ class EOSGNMIClient:
         IFACE_VTRANS_INGRESS = ("interfaces/interface[name={iface}]/ethernet/switched-vlan/vlan-translation/"
                                 "ingress[translation-key={vlan}]")
         IFACE_PC = "interfaces/interface[name={iface}]/aggregation"
-        IFACE_PC_VLANS = "interfaces/interface[name={iface}]/aggregation/switched-vlan"
+        IFACE_PC_VTRUNKS = "interfaces/interface[name={iface}]/aggregation/switched-vlan/config/trunk-vlans"
         IFACE_PC_NATIVE_VLAN = "interfaces/interface[name={iface}]/aggregation/switched-vlan/config/native-vlan"
         IFACE_PC_VTRANS = "interfaces/interface[name={iface}]/aggregation/switched-vlan/vlan-translation"
         IFACE_PC_VTRANS_EGRESS = ("interfaces/interface[name={iface}]/aggregation/switched-vlan/vlan-translation/"
@@ -568,7 +568,7 @@ class EOSSwitch(SwitchBase):
                     if iface.native_vlan:
                         config_req.delete.append(EOSGNMIClient.PATHS.IFACE_PC_NATIVE_VLAN.format(iface=iface.name))
                     if iface.trunk_vlans:
-                        config_req.replace.append((EOSGNMIClient.PATHS.IFACE_PC_VLANS.format(iface=iface.name),
+                        config_req.replace.append((EOSGNMIClient.PATHS.IFACE_PC_VTRUNKS.format(iface=iface.name),
                                                    calc_delete_range(all_ifaces_cfg, iface.name, iface)))
 
                     # NOTE: we only delete the translations based on one part of the translation
@@ -590,7 +590,7 @@ class EOSSwitch(SwitchBase):
 
                     # delete trunk vlans
                     if iface.trunk_vlans:
-                        config_req.replace.append((EOSGNMIClient.PATHS.IFACE_VLANS.format(iface=iface_name),
+                        config_req.replace.append((EOSGNMIClient.PATHS.IFACE_VTRUNKS.format(iface=iface_name),
                                                    calc_delete_range(all_ifaces_cfg, iface_name, iface)))
                     # delete translations
                     # NOTE: see note above for PC translations

--- a/networking_ccloud/tests/unit/ml2/agent/eos/test_switch.py
+++ b/networking_ccloud/tests/unit/ml2/agent/eos/test_switch.py
@@ -228,11 +228,12 @@ class TestEOSConfigUpdates(base.TestCase):
                 'interfaces/interface[name=Ethernet4/2]/ethernet/switched-vlan/vlan-translation/'
                 'ingress[translation-key=1337]'],
             'replace': [
-                ('interfaces/interface[name=Port-Channel23]/aggregation/switched-vlan',
+                ('interfaces/interface[name=Port-Channel23]/aggregation/switched-vlan/config/trunk-vlans',
                  ['2002', '2005', '2323..2327']),
-                ('interfaces/interface[name=Ethernet4/1]/ethernet/switched-vlan', ['1003']),
-                ('interfaces/interface[name=Ethernet4/2]/ethernet/switched-vlan', []),
-                ('interfaces/interface[name=Ethernet23/1]/ethernet/switched-vlan', ['999..1000', '1002'])],
+                ('interfaces/interface[name=Ethernet4/1]/ethernet/switched-vlan/config/trunk-vlans', ['1003']),
+                ('interfaces/interface[name=Ethernet4/2]/ethernet/switched-vlan/config/trunk-vlans', []),
+                ('interfaces/interface[name=Ethernet23/1]/ethernet/switched-vlan/config/trunk-vlans',
+                 ['999..1000', '1002'])],
             'update': []}
 
         cu = messages.SwitchConfigUpdate(switch_name="seagull-sw1", operation=messages.OperationEnum.remove)


### PR DESCRIPTION
GNMI+EOS have problems with trunk-vlans not being strings, so we now
convert them all to strings. While we're at it, we're also compressing
them when sending them to the switch, which will lead to a smaller GNMI
request size (setting vlan [1, 2, 3, 4] will result in setting vlan
["1..4"]).