### PR TITLE
Change VLAN deletion order check

### DIFF
--- a/networking_ccloud/ml2/agent/eos/switch.py
+++ b/networking_ccloud/ml2/agent/eos/switch.py
@@ -274,8 +274,8 @@ class EOSSwitch(SwitchBase):
                 config_req.get_list(operation).append(mapcfg)
         else:
             # delete vlan mapping only if it has the right vni
-            for curr_map in curr_maps:
-                for os_map in vxlan_maps:
+            for os_map in vxlan_maps:
+                for curr_map in curr_maps:
                     if curr_map.vlan == os_map.vlan:
                         if curr_map.vni == os_map.vni:
                             config_req.delete.append(EOSGNMIClient.PATHS.VXMAP_VLAN.format(vlan=curr_map.vlan))


### PR DESCRIPTION
For VLAN-VNI mappings we check that the VNI is mapped to the right VLAN
(the one we want to delete), but before this commit this check was done
by iterating over all existing switch-VLANs and look if they exist in
the OpenStack config request. This leads to a lot of "VLAN not found on
switch" warnings, which is... wrong. Iterating over the OpenStack VLANs
and then looking on the switch is what was originally intented.