### PR TITLE
Make sure PCs are created when not existent on device

### DIFF
--- a/networking_ccloud/ml2/agent/eos/switch.py
+++ b/networking_ccloud/ml2/agent/eos/switch.py
@@ -525,7 +525,7 @@ class EOSSwitch(SwitchBase):
                 # port-channel configuration
                 normal_ifaces = []
                 if iface.portchannel_id is not None:
-                    data = {
+                    agg_data = {
                         'config': {
                             'arista-intf-augments:mlag': iface.portchannel_id,
                             'lag-type': 'LACP',
@@ -533,12 +533,21 @@ class EOSSwitch(SwitchBase):
                         },
                     }
                     if data_vlan:
-                        data['switched-vlan'] = {'config': data_vlan}
+                        agg_data['switched-vlan'] = {'config': data_vlan}
+
+                    data = {
+                        'name': iface.name,
+                        'config': {
+                            'name': iface.name,
+                            'type': 'iana-if-type:ieee8023adLag',
+                        },
+                        'aggregation': agg_data
+                    }
 
                     if iface.vlan_translations:
                         remove_stale_vlan_translations(iface.name, iface, is_pc=True)
 
-                    pc_cfg = (EOSGNMIClient.PATHS.IFACE_PC.format(iface=iface.name), data)
+                    pc_cfg = (EOSGNMIClient.PATHS.IFACE.format(iface=iface.name), data)
                     config_req.get_list(operation).append(pc_cfg)
                     normal_ifaces = iface.members or []
                 else:

--- a/networking_ccloud/tests/unit/ml2/agent/eos/test_switch.py
+++ b/networking_ccloud/tests/unit/ml2/agent/eos/test_switch.py
@@ -71,25 +71,55 @@ class TestEOSConfigUpdates(base.TestCase):
                                                              'import': ['65123:232323']}},
                                  'vlans': {'vlan': [{'config': {'vlan-id': 1000},
                                                      'vlan-id': 1000}]}}]}),
-            ('interfaces/interface[name=Port-Channel23]/aggregation',
-             {'config': {'arista-intf-augments:fallback': 'individual',
-                         'arista-intf-augments:mlag': 23,
-                         'lag-type': 'LACP'},
-              'switched-vlan': {'config': {'interface-mode': 'TRUNK',
-                                           'native-vlan': 1000,
-                                           'trunk-vlans': ['1000..1001'],
-                                           'vlan-translation': {'egress': [{'config': {'bridging-vlan': 2323,
-                                                                                       'translation-key': 1000},
-                                                                            'translation-key': 1000},
-                                                                           {'config': {'bridging-vlan': 1337,
-                                                                                       'translation-key': 1001},
-                                                                            'translation-key': 1001}],
-                                                                'ingress': [{'config': {'bridging-vlan': 1000,
-                                                                                        'translation-key': 2323},
-                                                                             'translation-key': 2323},
-                                                                            {'config': {'bridging-vlan': 1001,
-                                                                                        'translation-key': 1337},
-                                                                             'translation-key': 1337}]}}}}),
+            ('interfaces/interface[name=Port-Channel23]', {
+                'config': {
+                    'name': 'Port-Channel23',
+                    'type': 'iana-if-type:ieee8023adLag'
+                },
+                'name': 'Port-Channel23',
+                'aggregation': {
+                    'config': {
+                        'arista-intf-augments:fallback': 'individual',
+                        'arista-intf-augments:mlag': 23,
+                        'lag-type': 'LACP',
+                    },
+                    'switched-vlan': {
+                        'config': {
+                            'interface-mode': 'TRUNK',
+                            'native-vlan': 1000,
+                            'trunk-vlans': ['1000..1001'],
+                            'vlan-translation': {
+                                'egress': [{
+                                    'config': {
+                                        'bridging-vlan': 2323,
+                                        'translation-key': 1000
+                                    },
+                                    'translation-key': 1000
+                                }, {
+                                    'config': {
+                                        'bridging-vlan': 1337,
+                                        'translation-key': 1001
+                                    },
+                                    'translation-key': 1001
+                                }],
+                                'ingress': [{
+                                    'config': {
+                                        'bridging-vlan': 1000,
+                                        'translation-key': 2323
+                                    },
+                                    'translation-key': 2323
+                                }, {
+                                    'config': {
+                                        'bridging-vlan': 1001,
+                                        'translation-key': 1337
+                                    },
+                                    'translation-key': 1337
+                                }]
+                            }
+                        }
+                    }
+                }
+            }),
             ('interfaces/interface[name=Ethernet4/1]/ethernet',
              {'config': {'aggregate-id': 'Port-Channel23'},
               'switched-vlan': {'config': {'interface-mode': 'TRUNK',
@@ -398,22 +428,52 @@ class TestEOSConfigUpdates(base.TestCase):
             ],
             'replace': [],
             'update': [
-                ('interfaces/interface[name=Port-Channel23]/aggregation',
-                 {'config': {'arista-intf-augments:fallback': 'individual',
-                             'arista-intf-augments:mlag': 23,
-                             'lag-type': 'LACP'},
-                  'switched-vlan': {'config': {'vlan-translation': {'egress': [{'config': {'bridging-vlan': 42,
-                                                                                           'translation-key': 23},
-                                                                                'translation-key': 23},
-                                                                               {'config': {'bridging-vlan': 2000,
-                                                                                           'translation-key': 1000},
-                                                                                'translation-key': 1000}],
-                                                                    'ingress': [{'config': {'bridging-vlan': 23,
-                                                                                            'translation-key': 42},
-                                                                                 'translation-key': 42},
-                                                                                {'config': {'bridging-vlan': 1000,
-                                                                                            'translation-key': 2000},
-                                                                                 'translation-key': 2000}]}}}}),
+                ('interfaces/interface[name=Port-Channel23]', {
+                    'name': 'Port-Channel23',
+                    'config': {
+                        'name': 'Port-Channel23',
+                        'type': 'iana-if-type:ieee8023adLag'
+                    },
+                    'aggregation': {
+                        'config': {
+                            'arista-intf-augments:fallback': 'individual',
+                            'arista-intf-augments:mlag': 23,
+                            'lag-type': 'LACP'
+                        },
+                        'switched-vlan': {
+                            'config': {
+                                'vlan-translation': {
+                                    'egress': [{
+                                        'config': {
+                                            'bridging-vlan': 42,
+                                            'translation-key': 23
+                                        },
+                                        'translation-key': 23
+                                    }, {
+                                        'config': {
+                                            'bridging-vlan': 2000,
+                                            'translation-key': 1000
+                                        },
+                                        'translation-key': 1000
+                                    }],
+                                    'ingress': [{
+                                        'config': {
+                                            'bridging-vlan': 23,
+                                            'translation-key': 42
+                                        },
+                                        'translation-key': 42
+                                    }, {
+                                        'config': {
+                                            'bridging-vlan': 1000,
+                                            'translation-key': 2000
+                                        },
+                                        'translation-key': 2000
+                                    }]
+                                }
+                            }
+                        }
+                    }
+                }),
                 ('interfaces/interface[name=Ethernet23/1]/ethernet',
                  {'config': {'aggregate-id': 'Port-Channel23'},
                   'switched-vlan': {'config': {'vlan-translation': {'egress': [{'config': {'bridging-vlan': 42,


### PR DESCRIPTION
In the EOS agent we cannot only set the aggregation part of a Port-Channel, as then it won't be created it if is not already present on the device. Therefore we now define the whole interface when creating a Port-Channel, so this won't be a problem.