### PR TITLE
Add API call to create all port-channels

### DIFF
--- a/networking_ccloud/tests/unit/extensions/test_extensions.py
+++ b/networking_ccloud/tests/unit/extensions/test_extensions.py
@@ -375,3 +375,16 @@ class TestNetworkExtension(test_segment.SegmentTestCase, base.PortBindingHelper)
             # just make sure it looks somewhat relatable to what we expect / have set in the db
             self.assertEqual(10, len(cfg['config']['ifaces']))
             self.assertEqual([23, 42, 100], cfg['config']['ifaces'][0]['trunk_vlans'])
+
+    def test_create_all_portchannels(self):
+        with mock.patch.object(CCFabricSwitchAgentRPCClient, 'apply_config_update') as mock_acu:
+            resp = self.app.put("/cc-fabric/switches/create_all_portchannels")
+            self.assertTrue(resp.json['sync_sent'])
+            swcfgs = mock_acu.call_args[0][1]
+            self.assertEqual(1, mock_acu.call_count)
+            self.assertEqual(4, len(swcfgs))
+            for swcfg in swcfgs:
+                self.assertEqual(10, len(swcfg.ifaces))
+                for iface in swcfg.ifaces:
+                    self.assertTrue(iface.portchannel_id)
+                    self.assertEqual(iface.members, [])


### PR DESCRIPTION
With GNMI on Arista EOS we cannot reference a Port-Channel that already exists. As we don't want to split up our set() call in the agent and we only would need to do this a single time for the first time provisioning a switch we now offer an extra API call to create these Port-Channels on all devices.

I really would have liked to do this via collection_methods or collection_actions (comparable to member_actions) and there is also an example for this in Neutron (see the tagging extension or the quota extension), but I did not get this to work. Therefore I now do a "switch-case" in update() of the switch controller.