### PR TITLE
Replace only managed vlan objects on config replace

### DIFF
--- a/networking_ccloud/ml2/agent/common/agent.py
+++ b/networking_ccloud/ml2/agent/common/agent.py
@@ -83,12 +83,14 @@ class CCFabricSwitchAgent(manager.Manager, cc_agent_api.CCFabricSwitchAgentAPI):
 
     def _init_switches(self):
         """Init all switches the agent manages"""
-        for switch_conf in self.drv_conf.get_switches():
-            if switch_conf.platform != self.get_switch_class().get_platform():
-                continue
-            switch = self.get_switch_class()(switch_conf)
-            LOG.debug("Adding switch %s with user %s to switchpool", switch, switch.user)
-            self._switches.append(switch)
+        for sg_conf in self.drv_conf.switchgroups:
+            managed_vlans = sg_conf.get_managed_vlans(self.drv_conf)
+            for switch_conf in sg_conf.members:
+                if switch_conf.platform != self.get_switch_class().get_platform():
+                    continue
+                switch = self.get_switch_class()(switch_conf, self.drv_conf.global_config.asn_region, managed_vlans)
+                LOG.debug("Adding switch %s with user %s to switchpool", switch, switch.user)
+                self._switches.append(switch)
 
     def get_switch_by_name(self, name):
         for switch in self._switches:

--- a/networking_ccloud/ml2/agent/common/switch.py
+++ b/networking_ccloud/ml2/agent/common/switch.py
@@ -20,8 +20,10 @@ LOG = logging.getLogger(__name__)
 
 
 class SwitchBase(abc.ABC):
-    def __init__(self, sw_conf, timeout=20, verify_ssl=False):
+    def __init__(self, sw_conf, asn_region, managed_vlans, timeout=20, verify_ssl=False):
         self.sw_conf = sw_conf
+        self.asn_region = asn_region
+        self.managed_vlans = managed_vlans
         self.name = sw_conf.name
         self.host = sw_conf.host
         self.user = sw_conf.user


### PR DESCRIPTION
It was decided that we do not own all the VLANs and connected objects (vlan-vni mappings, evpn instances) on a device. Therefore we cannot just to a config replace and tell the switch of all the VLANs that we want to have on the device. What we have to do now is to look at all the VLANs on the device, see if they are still needed and if not AND are managed by us we delete them - case by case. The range of managed VLANs is pulled from the driver config - all vlan ranges + all infra net vlans that we manage.