### PR TITLE
Support unmanaged interfaces

### DIFF
--- a/networking_ccloud/common/config/config_driver.py
+++ b/networking_ccloud/common/config/config_driver.py
@@ -166,6 +166,7 @@ class SwitchPort(pydantic.BaseModel):
     lacp: bool = False
     portchannel_id: pydantic.conint(gt=0) = None
     members: List[str] = None
+    unmanaged: bool = False
 
     @pydantic.root_validator
     def only_allow_members_and_pc_id_with_lacp_enabled(cls, v):

--- a/networking_ccloud/ml2/agent/common/messages.py
+++ b/networking_ccloud/ml2/agent/common/messages.py
@@ -338,6 +338,8 @@ class SwitchConfigUpdateList:
             # interface config
             if not is_bgw:
                 for sp in switchports:
+                    if sp.unmanaged:
+                        continue
                     iface = scu.get_or_create_iface_from_switchport(sp)
                     iface.add_trunk_vlan(seg_vlan)
 

--- a/networking_ccloud/tests/common/config_fixtures.py
+++ b/networking_ccloud/tests/common/config_fixtures.py
@@ -74,8 +74,8 @@ def gen_switchport_names(switchgroup=None, switches=None, ports_per_switch=2, of
     return ports
 
 
-def make_switchport(switch, name, lacp=False, members=None):
-    return config_driver.SwitchPort(switch=switch, name=name, lacp=lacp, members=members)
+def make_switchport(switch, name, lacp=False, members=None, unmanaged=False):
+    return config_driver.SwitchPort(switch=switch, name=name, lacp=lacp, members=members, unmanaged=unmanaged)
 
 
 def make_lacp(pc_id, switchgroup, **kwargs):
@@ -108,9 +108,10 @@ def make_metagroup(switchgroup, hg_kwargs={}, meta_kwargs={}):
 
 
 def make_interconnect(role, host, switch_base, handle_azs):
+    unmanaged = role == config_driver.HostgroupRole.transit
     sp_name = f"{host}-1/1/1" if role != config_driver.HostgroupRole.bgw else None
     return config_driver.Hostgroup(binding_hosts=[host], role=role,
-                                   members=[make_switchport(f"{switch_base}-sw1", sp_name)],
+                                   members=[make_switchport(f"{switch_base}-sw1", sp_name, unmanaged=unmanaged)],
                                    handle_availability_zones=handle_azs)
 
 

--- a/networking_ccloud/tests/unit/extensions/test_extensions.py
+++ b/networking_ccloud/tests/unit/extensions/test_extensions.py
@@ -261,8 +261,8 @@ class TestNetworkExtension(test_segment.SegmentTestCase, base.PortBindingHelper)
             swcfgs = mock_acu.call_args[0][1]
             self.assertEqual({"transit1-sw1"}, set(s.switch_name for s in swcfgs))
             for swcfg in swcfgs:
-                for iface in swcfg.ifaces:
-                    self.assertEqual({111}, set(iface.trunk_vlans))
+                self.assertEqual([{'vni': 232323, 'vlan': 111}], swcfg.vxlan_maps)
+                self.assertIsNone(swcfg.ifaces)
 
     def test_switch_get_config(self):
         with mock.patch.object(CCFabricSwitchAgentRPCClient, 'get_switch_config') as mock_gsc:

--- a/networking_ccloud/tests/unit/ml2/test_mech_driver.py
+++ b/networking_ccloud/tests/unit/ml2/test_mech_driver.py
@@ -557,11 +557,10 @@ class TestCCFabricMechanismDriverInterconnects(CCFabricMechanismDriverTestBase):
                 self.assertEqual(1, len(s.bgp.vlans))
                 if s.switch_name.startswith("bgw"):
                     self.assertTrue(s.bgp.vlans[0].rd_evpn_domain_all)
-                else:
-                    # transit
-                    for iface in s.ifaces:
-                        self.assertIsNone(iface.native_vlan, "No native vlan for transits")
-                        self.assertEqual(1, len(iface.trunk_vlans))
+                # bgws don't have any interfaces
+                # transits are currently marked as unmanaged by default
+                # --> both don't have any iface config attached
+                self.assertIsNone(s.ifaces)
 
     def test_transit_bgw_deallocation_on_network_delete(self):
         with mock.patch.object(CCFabricSwitchAgentRPCClient, 'apply_config_update') as mock_acu:


### PR DESCRIPTION
An unmanaged interface is any interface we want to keep in the driver config, but do not want to push any config for. This has been introduced for transit interconnects, as we don't have the full vlan list to properly control the allowed vlan list for now, but it can also be used for other interfaces. Due to it being thought out as a transit feature I decided to also model the config fixtures for the tests according to this and make transit ports by default unmanaged.

I chose to use unmanaged as a config option in favor to just making all transit interfaces unmanaged by default, because this is a Converged Cloud design decision. The driver could very well be run with managed transit interfaces (as opposed to the BGWs, where we just don't have any interface to manage).