### PR TITLE
Fix missing logging for fabricoperations

### DIFF
--- a/networking_ccloud/extensions/fabricoperations.py
+++ b/networking_ccloud/extensions/fabricoperations.py
@@ -37,7 +37,8 @@ from networking_ccloud.ml2.agent.common import messages as agent_msg
 from networking_ccloud.ml2.plugin import FabricPlugin
 
 
-LOG = logging.getLogger(__name__)
+# we can't use __name__ for this logger, as stevedore only loads us as "fabricoperations"
+LOG = logging.getLogger("networking_ccloud.extensions.fabricoperations")
 
 
 ACCESS_RULE = "context_is_cloud_admin"


### PR DESCRIPTION
fabricoperations is instantiated by stevedore as a plugin. Due to this, the logger becomes the name "fabricoperations" instead of its fully qualified name and thus avoids being configured in the same way as all other loggers we have. We now hardcode the name of this logger to avoid this.