### PR TITLE
Talk to multiple switches in parallel

### DIFF
--- a/networking_ccloud/ml2/agent/common/switch.py
+++ b/networking_ccloud/ml2/agent/common/switch.py
@@ -13,10 +13,26 @@
 #    under the License.
 
 import abc
+from functools import wraps
 
+from futurist import ThreadPoolExecutor
+from oslo_concurrency import lockutils
 from oslo_log import log as logging
 
 LOG = logging.getLogger(__name__)
+
+
+def run_in_executor(fn):
+    """Decorator to run a method in the ThreadPoolExecutor of the class
+
+    The wrapped method thus returns a futurist.Future now instead of its actual
+    result.
+    """
+    @wraps(fn)
+    def wrapped(self, *args, **kwargs):
+        return self._executor.submit(fn, self, *args, **kwargs)
+
+    return wrapped
 
 
 class SwitchBase(abc.ABC):
@@ -31,6 +47,7 @@ class SwitchBase(abc.ABC):
         self.timeout = timeout
         self._verify_ssl = verify_ssl
         self._api = None
+        self._executor = ThreadPoolExecutor(max_workers=5)
 
     @classmethod
     @abc.abstractmethod
@@ -51,11 +68,24 @@ class SwitchBase(abc.ABC):
     def __str__(self):
         return f"{self.name} ({self.host})"
 
+    @run_in_executor
     def get_switch_status(self):
+        return self._get_switch_status()
+
+    def _get_switch_status(self):
         raise NotImplementedError
 
+    @run_in_executor
     def get_config(self):
+        return self._get_config()
+
+    def _get_config(self):
         raise NotImplementedError
 
+    @run_in_executor
     def apply_config_update(self, config):
+        with lockutils.lock(name=f"apply-config-update-{self.name}"):
+            return self._apply_config_update(config)
+
+    def _apply_config_update(self, config):
         raise NotImplementedError

--- a/networking_ccloud/ml2/agent/eos/switch.py
+++ b/networking_ccloud/ml2/agent/eos/switch.py
@@ -18,7 +18,6 @@ import re
 import time
 from typing import List, Optional
 
-from oslo_concurrency import lockutils
 from oslo_log import log as logging
 from pygnmi.client import gNMIclient, gNMIException
 
@@ -206,7 +205,7 @@ class EOSSwitch(SwitchBase):
 
         return result
 
-    def get_switch_status(self):
+    def _get_switch_status(self):
         # FIXME: we can get this without cli, but sometimes the chassis/model seems to be empty
         #        once we figure out when this is the case we can use the code below instead of cli:/show version
         # ver, model, uptime_ns = self.api.get(path=['system/config/hostname',
@@ -737,7 +736,7 @@ class EOSSwitch(SwitchBase):
 
         return config_req
 
-    def get_config(self) -> agent_msg.SwitchConfigUpdate:
+    def _get_config(self) -> agent_msg.SwitchConfigUpdate:
         # get infos from the device for everything that we have a model for
         config = agent_msg.SwitchConfigUpdate(switch_name=self.name, operation=Op.add)
         config.vlans = self.get_vlan_config()
@@ -745,10 +744,6 @@ class EOSSwitch(SwitchBase):
         config.bgp = self.get_bgp_config()
         config.ifaces = self.get_ifaces_config()
         return config
-
-    def apply_config_update(self, config):
-        with lockutils.lock(name=f"apply-config-update-{self.name}"):
-            return self._apply_config_update(config)
 
     def _apply_config_update(self, config):
         # FIXME: threading model (does this call block or not?)

--- a/networking_ccloud/ml2/agent/nxos/switch.py
+++ b/networking_ccloud/ml2/agent/nxos/switch.py
@@ -86,7 +86,7 @@ class NXOSSwitch(SwitchBase):
 
         return result
 
-    def get_switch_status(self):
+    def _get_switch_status(self):
         ver = self.send_cmd("show version")
         return {
             'name': self.name,

--- a/networking_ccloud/tests/unit/ml2/agent/eos/test_switch.py
+++ b/networking_ccloud/tests/unit/ml2/agent/eos/test_switch.py
@@ -42,7 +42,7 @@ class TestEOSConfigUpdates(base.TestCase):
         cu = messages.SwitchConfigUpdate(switch_name="seagull-sw1", operation=messages.OperationEnum.add)
         cu.add_vlan(1000, "nest")
         cu.add_vlan(1001, "basket")
-        self.switch.apply_config_update(cu)
+        self.switch.apply_config_update(cu).result()
         self.switch._api.set.assert_called_with(update=expected_update, delete=[], replace=[])
 
     def test_add_everything(self):
@@ -187,7 +187,7 @@ class TestEOSConfigUpdates(base.TestCase):
         iface2.add_trunk_vlan(1001)
         cu.add_iface(iface2)
 
-        self.switch.apply_config_update(cu)
+        self.switch.apply_config_update(cu).result()
         self.switch._api.set.assert_called_with(update=expected_update_config, replace=[],
                                                 delete=expected_delete_config)
 
@@ -294,7 +294,7 @@ class TestEOSConfigUpdates(base.TestCase):
         iface2.add_trunk_vlan(2001)
         cu.add_iface(iface2)
 
-        self.switch.apply_config_update(cu)
+        self.switch.apply_config_update(cu).result()
         self.switch._api.set.assert_called_with(**expected_config)
 
     def test_add_vlan_map_with_existing(self):
@@ -317,7 +317,7 @@ class TestEOSConfigUpdates(base.TestCase):
         cu.add_vxlan_map(232323, 1000)
         cu.add_vxlan_map(424242, 2000)
 
-        self.switch.apply_config_update(cu)
+        self.switch.apply_config_update(cu).result()
         self.switch._api.set.assert_called_with(**expected_config)
 
     def test_replace_trunk_vlans(self):
@@ -333,7 +333,7 @@ class TestEOSConfigUpdates(base.TestCase):
         iface.add_trunk_vlan(1001)
         cu.add_iface(iface)
 
-        self.switch.apply_config_update(cu)
+        self.switch.apply_config_update(cu).result()
         self.switch._api.set.assert_called_with(**expected_config)
 
     def test_replace_vlans(self):
@@ -362,7 +362,7 @@ class TestEOSConfigUpdates(base.TestCase):
         cu.add_vlan(2000, "nest")
         cu.add_vlan(2001, "basket")
 
-        self.switch.apply_config_update(cu)
+        self.switch.apply_config_update(cu).result()
         self.switch._api.set.assert_called_with(**expected_config)
 
     def test_update_vxlan_maps(self):
@@ -389,7 +389,7 @@ class TestEOSConfigUpdates(base.TestCase):
         cu.add_vxlan_map(23, 42)
         cu.add_vxlan_map(232323, 1337)
 
-        self.switch.apply_config_update(cu)
+        self.switch.apply_config_update(cu).result()
         self.switch._api.set.assert_called_with(**expected_config)
 
     def test_replace_vxlan_maps(self):
@@ -419,7 +419,7 @@ class TestEOSConfigUpdates(base.TestCase):
         cu.add_vxlan_map(424242, 2000)
         cu.add_vxlan_map(200444, 2001)
 
-        self.switch.apply_config_update(cu)
+        self.switch.apply_config_update(cu).result()
         self.switch._api.set.assert_called_with(**expected_config)
 
     def test_update_vlan_translations(self):
@@ -532,7 +532,7 @@ class TestEOSConfigUpdates(base.TestCase):
         iface.add_vlan_translation(1000, 2000)
         cu.add_iface(iface)
 
-        self.switch.apply_config_update(cu)
+        self.switch.apply_config_update(cu).result()
         self.switch._api.set.assert_called_with(**expected_config)
         self.switch._api.set.reset_mock()
 
@@ -645,7 +645,7 @@ class TestEOSConfigUpdates(base.TestCase):
         cu.bgp.add_vlan(2000, 232323, 1)
         cu.bgp.add_vlan(2004, 424242, 3, bgw_mode=True)
 
-        self.switch.apply_config_update(cu)
+        self.switch.apply_config_update(cu).result()
         self.switch._api.set.assert_has_calls([mock.call(**expected_cli_config), mock.call(**expected_config)])
 
     def test_bgp_vlans_bgw_mode(self):
@@ -677,7 +677,7 @@ class TestEOSConfigUpdates(base.TestCase):
         cu.bgp = messages.BGP(asn="65000", asn_region="65123", switchgroup_id=4223)
         cu.bgp.add_vlan(1000, 232323, 1, bgw_mode=True)
 
-        self.switch.apply_config_update(cu)
+        self.switch.apply_config_update(cu).result()
         self.switch._api.set.assert_has_calls([mock.call(**expected_cli_config), mock.call(**expected_config)])
 
 
@@ -771,7 +771,7 @@ class TestEOSSwitch(base.TestCase):
         cu.add_iface(iface)
         cu.sort()
 
-        config = self.switch.get_config()
+        config = self.switch.get_config().result()
         config.sort()
         self.assertEqual(cu.dict(exclude_unset=True, exclude_defaults=True),
                          config.dict(exclude_unset=True, exclude_defaults=True))

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ pydantic
 pyyaml
 
 # driver requirements
+futurist
 manhole
 neutron-lib
 neutron


### PR DESCRIPTION
When calling get_config(), get_switch_status() or apply_config_update() on the CCFabricSwitchAgent, we now submit the tasks to all (referenced) switches. They then do their work in parallel and we wait for all their results in a second for-loop, building the result dict.

This works via ThreadPoolExecutor from futurist. We decided to use it instead of concurrent.fututures.ThreadPoolExecutor, because it also gathers some statistics we might want at some time and otherwise works pretty much the same.

This changes the interface of SwitchBase. Child classes now have to implement _get_config(), _get_switch_status() and _apply_config_update() for the actual implementation, so we don't have to rewrap those implementation methods with @run_in_executor again. SwitchBase's get_config(), get_switch_status() and apply_config_update() now return futurist.Future instances. The actual result needs to be retrieved from them via their result() method.