### PR TITLE
Allow Hostgroups to have "extra vlans"

### DIFF
--- a/networking_ccloud/common/config/config_driver.py
+++ b/networking_ccloud/common/config/config_driver.py
@@ -299,6 +299,9 @@ class Hostgroup(pydantic.BaseModel):
     # infra networks attached to hostgroup
     infra_networks: List[InfraNetwork] = []
 
+    # vlans that are added to all allowed-vlan list without managing the vlan on switch
+    extra_vlans: List[pydantic.conint(gt=1, lt=4095)] = None
+
     _vlan_pool: str = None
 
     class Config:

--- a/networking_ccloud/extensions/fabricoperations.py
+++ b/networking_ccloud/extensions/fabricoperations.py
@@ -320,6 +320,8 @@ class SwitchesController(wsgi.Controller):
                 for inet in hg.infra_networks:
                     # FIXME: exclude hosts
                     scul.add_binding_host_to_config(hg, inet.name, inet.vni, inet.vlan)
+            if hg.extra_vlans:
+                scul.add_extra_vlans(hg)
         self._clean_switches(scul, switch)
         try:
             config_generated = scul.execute(request.context)
@@ -388,6 +390,8 @@ class SwitchesController(wsgi.Controller):
                 for inet in hg.infra_networks:
                     # FIXME: exclude hosts
                     scul.add_binding_host_to_config(hg, inet.name, inet.vni, inet.vlan)
+            if hg.extra_vlans:
+                scul.add_extra_vlans(hg)
             if hg.role:
                 # transits/BGWs don't have bindings, so bind all physnets
                 # find all physnets or interconnects scheduled


### PR DESCRIPTION
"Extra vlans" are vlans, that should be present on an interface, but get no vxlan-vlan mapping, no bgp entries and don't depend on a port binding to be present. Similar to infra networks they will only be provisioned on switch config replace or when replacing the whole switch config. They will be realized as a simple extra trunk vlan in the "trunk allowed vlans" list of an interface.