### PR TITLE
Always set RD, even if set via cli for BGWs

### DIFF
--- a/networking_ccloud/ml2/agent/eos/switch.py
+++ b/networking_ccloud/ml2/agent/eos/switch.py
@@ -444,11 +444,10 @@ class EOSSwitch(SwitchBase):
                 ]
 
                 # rd
+                inst['config']['route-distinguisher'] = bgp_vlan.rd
                 if bgp_vlan.rd_evpn_domain_all:
                     # FIXME: this should be done via model, once we have it
                     cli.append(("cli:", f"rd evpn domain all {bgp_vlan.rd}"))
-                else:
-                    inst['config']['route-distinguisher'] = bgp_vlan.rd
 
                 # route-targets
                 if bgp_vlan.rt_imports or bgp_vlan.rt_exports:

--- a/networking_ccloud/tests/unit/ml2/agent/eos/test_switch.py
+++ b/networking_ccloud/tests/unit/ml2/agent/eos/test_switch.py
@@ -615,6 +615,7 @@ class TestEOSConfigUpdates(base.TestCase):
               {
                   'config': {
                       'name': '2004',
+                      'route-distinguisher': '4223:424242',
                       'redistribute': ['LEARNED', 'ROUTER_MAC', 'HOST_ROUTE']
                   },
                   'name': '2004',
@@ -665,7 +666,8 @@ class TestEOSConfigUpdates(base.TestCase):
             'delete': [],
             'replace': [],
             'update': [('arista/eos/arista-exp-eos-evpn:evpn/evpn-instances/evpn-instance[name=1000]',
-                        {'config': {'name': '1000', 'redistribute': ['LEARNED', 'ROUTER_MAC', 'HOST_ROUTE']},
+                        {'config': {'name': '1000', 'redistribute': ['LEARNED', 'ROUTER_MAC', 'HOST_ROUTE'],
+                                    'route-distinguisher': '4223:232323'},
                          'name': '1000',
                          'route-target': {'config': {'export': ['1:232323'],
                                                      'import': ['1:232323']}},


### PR DESCRIPTION
We need to always set the route-distinguisher. In the past we didn't do this when we already configured the RD via cli in the case of BGWs, as I thought this was already enough. If we set the RD only via cli with "rd evpn domain all" and THEN do a replace on this evpn instance without a RD being present in the config request the cli statement will change to "rd evpn domain remote" and won't export routes learned from other BGWs. As we want a working fabric, we now always add the RD to an evpn instance config request.