### PR TITLE
backdoor locals: Fix print_semaphores() for threading

### DIFF
--- a/networking_ccloud/ml2/agent/common/backdoor.py
+++ b/networking_ccloud/ml2/agent/common/backdoor.py
@@ -43,7 +43,7 @@ def _print_semaphores():
     # local import as we don't want to keep that local variable in global scope
     from oslo_concurrency.lockutils import _semaphores
 
-    print('\n'.join(sorted([f"{name} - {len(s._Semaphore__cond._Condition__waiters)}"
+    print('\n'.join(sorted([f"{name} - {len(s._cond._waiters)}"
                             for name, s in _semaphores._semaphores.items()])))
 
 


### PR DESCRIPTION
The previous version was working with eventlet, but since we're using threading here, we need to adapt it.