### PR TITLE
Add agent to agent backdoor locals

### DIFF
--- a/networking_ccloud/ml2/agent/eos/agent.py
+++ b/networking_ccloud/ml2/agent/eos/agent.py
@@ -42,6 +42,11 @@ class CCFabricEOSSwitchAgent(CCFabricSwitchAgent):
 
         return status
 
+    def backdoor_locals(self):
+        return {
+            'agent': self,
+        }
+
 
 def main():
     CCFabricEOSSwitchAgent.run_agent_main()


### PR DESCRIPTION
With this we have the current agent directly accessible in the backdoor as "agent" and can immediately start debugging.