### PR TITLE
Add Switches ThreadPool Stats section to GMR

### DIFF
--- a/networking_ccloud/ml2/agent/common/agent.py
+++ b/networking_ccloud/ml2/agent/common/agent.py
@@ -24,6 +24,7 @@ from networking_ccloud.common.config import get_driver_config
 from networking_ccloud.common import constants as cc_const
 from networking_ccloud.common import exceptions as cc_exc
 from networking_ccloud.ml2.agent.common import api as cc_agent_api
+from networking_ccloud.ml2.agent.common import gmr
 from networking_ccloud.ml2.agent.common import messages as agent_msg
 from networking_ccloud.ml2.agent.common.service import ThreadedService
 
@@ -53,6 +54,8 @@ class CCFabricSwitchAgent(manager.Manager, cc_agent_api.CCFabricSwitchAgentAPI):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        gmr.register_thread_pool_stats(self)
 
         self._switches = []
         self.drv_conf = get_driver_config()

--- a/networking_ccloud/ml2/agent/common/gmr.py
+++ b/networking_ccloud/ml2/agent/common/gmr.py
@@ -1,0 +1,54 @@
+# Copyright 2022 SAP SE
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from functools import partial
+
+from oslo_reports import guru_meditation_report as gmr
+from oslo_reports.models import with_default_views as mwdv
+from oslo_reports.views.text import generic as text_views
+
+
+class ThreadPoolStatsView(object):
+    FORMAT_STR = (
+        "------{header: ^60}------\n"
+        "Executed: {stats.executed}\n"
+        "Failures: {stats.failures}\n"
+        "Cancelled: {stats.cancelled}\n"
+        "Runtime: {stats.runtime}\n"
+        "Avg Runtime: {stats.average_runtime}\n"
+        "Queue Size: {queue_size}\n"
+    )
+
+    def __call__(self, model):
+        return self.FORMAT_STR.format(
+            header=f" ThreadPool for {model.switch_name} ",
+            stats=model.stats,
+            queue_size=model.queue_size
+        )
+
+
+def thread_pool_stats_generator(agent):
+    thread_pool_stats_models = [
+        mwdv.ModelWithDefaultViews(dict(switch_name=switch.name, stats=switch._executor.statistics,
+                                        queue_size=switch._executor._work_queue.qsize()),
+                                   text_view=ThreadPoolStatsView())
+        for switch in agent._switches
+    ]
+    return mwdv.ModelWithDefaultViews(thread_pool_stats_models,
+                                      text_view=text_views.MultiView())
+
+
+def register_thread_pool_stats(agent):
+    """Enable exposing the ThreadPool statistics of agent's switches"""
+    gmr.TextGuruMeditation.register_section('Switches ThreadPool Stats',
+                                            partial(thread_pool_stats_generator, agent))


### PR DESCRIPTION
We extend the GuruMeditationReport with a section "Switches ThreadPool Stats" which prints the stats of the executor for each switch including the queue size.