### PR TITLE
Add show_agent_queue_size() to backdoor locals

### DIFF
--- a/networking_ccloud/ml2/agent/common/agent.py
+++ b/networking_ccloud/ml2/agent/common/agent.py
@@ -12,6 +12,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from operator import attrgetter
 import sys
 
 from neutron.common import config as common_config
@@ -171,3 +172,15 @@ class CCFabricSwitchAgent(manager.Manager, cc_agent_api.CCFabricSwitchAgentAPI):
             result[switch_name] = future.result()
 
         return result
+
+    def backdoor_locals(self):
+
+        def show_agent_queue_size():
+            """Print out each switch with the queue size of their ThreadPoolExecutor"""
+            for switch in sorted(self._switches, key=attrgetter('name')):
+                print(switch.name, switch._executor._work_queue.qsize())
+
+        return {
+            'agent': self,
+            'show_agent_queue_size': show_agent_queue_size,
+        }

--- a/networking_ccloud/ml2/agent/eos/agent.py
+++ b/networking_ccloud/ml2/agent/eos/agent.py
@@ -42,11 +42,6 @@ class CCFabricEOSSwitchAgent(CCFabricSwitchAgent):
 
         return status
 
-    def backdoor_locals(self):
-        return {
-            'agent': self,
-        }
-
 
 def main():
     CCFabricEOSSwitchAgent.run_agent_main()


### PR DESCRIPTION
This is a manager-local backdoor-local and shows the threads currently waiting to run for each switch.