### PR TITLE
Sync switchgroup in one go via API

### DIFF
--- a/networking_ccloud/tests/unit/common/test_driver_config.py
+++ b/networking_ccloud/tests/unit/common/test_driver_config.py
@@ -233,9 +233,9 @@ class TestDriverConfig(base.TestCase):
         self.drv_conf = cfix.make_config(switchgroups=switchgroups, hostgroups=hostgroups)
         _override_driver_config(self.drv_conf)
 
-    def test_get_hostgroups_by_switch(self):
+    def test_get_hostgroups_by_switches(self):
         switch = self.drv_conf.get_switch_by_name("seagull-sw1")
-        hgs = self.drv_conf.get_hostgroups_by_switch(switch.name)
+        hgs = self.drv_conf.get_hostgroups_by_switches([switch.name])
         expected_groups = set(["nova-compute-seagull"] + [f"node{i:03d}-seagull" for i in range(1, 11)])
         self.assertEqual(expected_groups, set(hg.binding_host_name for hg in hgs))
 


### PR DESCRIPTION
With most of the API calls of SwitchgroupsController we just call the SwitchesController for each member of the switchgroup. If we don't expect a call to take a long time this might be okay, but with the switch sync taking something between 15-40s for some devices we want to parallelize these requests. Therefore we now generate the SwitchConfigUpdateList once for the switchgroup (which is essentially what we did before) let the SwitchesController clean out the switch it doesn't need to sync. With this SwitchgroupsController can just use this functionality and sync a switchgroup with a single RPC call.