### PR TITLE
Switch to distinct read and write ThreadPools

### DIFF
--- a/networking_ccloud/ml2/agent/common/agent.py
+++ b/networking_ccloud/ml2/agent/common/agent.py
@@ -92,7 +92,8 @@ class CCFabricSwitchAgent(manager.Manager, cc_agent_api.CCFabricSwitchAgentAPI):
         # usually called by neutron.service.Service at end of stop()
         LOG.info("Agent shutting down")
         for switch in self._switches:
-            switch._executor.shutdown()
+            switch._read_executor.shutdown()
+            switch._write_executor.shutdown()
         LOG.info("Agent shut down")
 
     def initialize_rpc_hook(self, conn):
@@ -181,7 +182,8 @@ class CCFabricSwitchAgent(manager.Manager, cc_agent_api.CCFabricSwitchAgentAPI):
         def show_agent_queue_size():
             """Print out each switch with the queue size of their ThreadPoolExecutor"""
             for switch in sorted(self._switches, key=attrgetter('name')):
-                print(switch.name, switch._executor._work_queue.qsize())
+                print(f"{switch.name:<21} read {switch._read_executor._work_queue.qsize():>3} "
+                      f"write {switch._write_executor._work_queue.qsize():>3}")
 
         return {
             'agent': self,

--- a/networking_ccloud/ml2/agent/common/gmr.py
+++ b/networking_ccloud/ml2/agent/common/gmr.py
@@ -25,7 +25,7 @@ class ThreadPoolStatsView(object):
         "Failures: {stats.failures}\n"
         "Cancelled: {stats.cancelled}\n"
         "Runtime: {stats.runtime}\n"
-        "Avg Runtime: {stats.average_runtime}\n"
+        "Avg Runtime: {average_runtime}\n"
         "Queue Size: {queue_size}\n"
     )
 
@@ -33,6 +33,7 @@ class ThreadPoolStatsView(object):
         return self.FORMAT_STR.format(
             header=f" ThreadPool of {model.switch_name} for {model.type}",
             stats=model.stats,
+            average_runtime=model.stats.average_runtime if model.stats.executed else None,
             queue_size=model.queue_size
         )
 


### PR DESCRIPTION
We don't want the writes to starve out the reads just because they are slower and clog up the queue. We also want better statistics on the average runtime for writes - which take a lock and thus block other threads currently executed in the ThreadPool from finishing.

Therefore, we introduce a second ThreadPool and use one for reading and one for writing.

This commit does the appropriate changes to SwitchBase, the backdoor-locals, the agent and our custom GMR reporting.