### PR TITLE
Do not redirect stderr in backdoor

### DIFF
--- a/networking_ccloud/ml2/agent/common/service.py
+++ b/networking_ccloud/ml2/agent/common/service.py
@@ -242,4 +242,5 @@ class ThreadedService:
         # let the Manager define additional functions for the backdoor shell
         if hasattr(self.manager, 'backdoor_locals'):
             locals_.update(self.manager.backdoor_locals())
-        manhole.install(patch_fork=False, socket_path=socket_path, daemon_connection=True, locals=locals_)
+        manhole.install(patch_fork=False, socket_path=socket_path, daemon_connection=True, locals=locals_,
+                        redirect_stderr=False)


### PR DESCRIPTION
We don't tell manhole to redirect stderr anymore, because it would make the GuruMeditationReport print only into the manhole thread and not into the logs anymore. This defeats part of the purpose of the GMR: that we still get a state from the process, even if the backdoor doesn't work anymore.
Additionally, redirecting stderr didn't have the wanted effect of showing us tracebacks/exceptions of code we run in the backdoor. We need to investigate further how we could make that work.