### PR TITLE
Let a full sync flush the ThreadPool

### DIFF
--- a/networking_ccloud/ml2/agent/common/agent.py
+++ b/networking_ccloud/ml2/agent/common/agent.py
@@ -30,6 +30,7 @@ from networking_ccloud.ml2.agent.common import api as cc_agent_api
 from networking_ccloud.ml2.agent.common import gmr
 from networking_ccloud.ml2.agent.common import messages as agent_msg
 from networking_ccloud.ml2.agent.common.service import ThreadedService
+from networking_ccloud.ml2.agent.common.switch import FullSyncScheduled
 
 LOG = logging.getLogger(__name__)
 
@@ -175,7 +176,10 @@ class CCFabricSwitchAgent(manager.Manager, cc_agent_api.CCFabricSwitchAgentAPI):
             futures.append((update.switch_name, switch.apply_config_update(update)))
 
         for switch_name, future in futures:
-            result[switch_name] = future.result()
+            try:
+                result[switch_name] = future.result()
+            except FullSyncScheduled as e:
+                result[switch_name] = e.future.result()
 
         return result
 


### PR DESCRIPTION
Whenever we schedule a full-sync, we want - nearly - all other tasks to be flushed out of the write ThreadPool for a switch, because the full-sync will do the changes other tasks would do anyways.

To implement this, we use a variable guarded by a lock. This variable is either set to None if no full-sync is currently waiting to run or to a Future object for the scheduled full-sync.

Before scheduling a new task, a thread checks the guarded variable to see if a full-sync is scheduled already and returns the full-sync Future instead if that's the case.

Already scheduled tasks check once they start running, if there's a full-sync waiting to run by checking the guarded variable. If they find a scheduled full-sync, they raise FullSyncScheduled which contains the full-sync Future in the "future" attribute. Callers can then decide if they return immediately or wait for the full-sync to finish - but they have to catch that exception.

There are 2 ways a full-sync might be scheduled: the normal way either via RPC or periodic task OR by a task getting scheduled and finding the queue in bad shape. Whenever we schedule a full-sync, the function "run_full_sync" takes the lock of the guarded variable. If the function finds the guarded variable already set after taking the lock, it returns the Future, because there's no need to schedule another full-sync. If the variable isn't set, it submits the full-sync function to the ThreadPool (i.e. it schedules the full-sync) and sets the variable to the returned Future.

To make sure we don't lose any updates, a starting full-sync will unset the guarded variable before doing any actual work. This makes sure that updates of tasks getting submitted in the middle of a full-sync will not be missed until next full-sync.