### PR TITLE
Pass config context for vlan range override to driver config

### DIFF
--- a/doc/source/configuration/config-input.rst
+++ b/doc/source/configuration/config-input.rst
@@ -108,7 +108,7 @@ If for a device a different (or reduced) range is in effect it must be expressed
             "evpn": {
                 "tenant-vlan-range": [
                     "2000",
-                    "2100-3000"
+                    "2100:3000"
                 ],
             }
         }


### PR DESCRIPTION
The field in the netbox config context for vlan range override nis now utilized and passed on in the driver config. Also slightly adjusting the docs to follow the formatting.