### PR TITLE
Add address scopes to VRF config

### DIFF
--- a/networking_ccloud/common/config/config_driver.py
+++ b/networking_ccloud/common/config/config_driver.py
@@ -452,6 +452,7 @@ class Hostgroup(pydantic.BaseModel):
 
 class VRF(pydantic.BaseModel):
     name: str
+    address_scopes: List[str] = []
 
     # magic number we use for vni, rt import/export calculation
     number: pydantic.conint(gt=0)


### PR DESCRIPTION
We need a mapping from address scope names to VRFs. This is required for the l3 part, where we want to tell a switch into which VRF networks of an address scope should be put.