### PR TITLE
Add _on_done() to ThreadedLoopingCallBase

### DIFF
--- a/networking_ccloud/ml2/agent/common/loopingcall.py
+++ b/networking_ccloud/ml2/agent/common/loopingcall.py
@@ -43,6 +43,9 @@ class ThreadedLoopingCallBase(loopingcall.LoopingCallBase):
         super().__init__(*args, **kwargs)
         self._abort = threading.Event()
 
+    def _on_done(self, *args, **kwargs):
+        self._thread = None
+
     def _start(self, idle_for, initial_delay=None, stop_on_exception=True):
         """Start the looping
 


### PR DESCRIPTION
This method is necessary, because oslo.service's method requires a "gt" argument, which we don't have to supply here, as the thread is not cleaned up, yet, when the callback is called. Therefore, we overwrite our parent's _on_done() with a version that doesn't require the argument.