### PR TITLE
Pin GitHub actions to 20.04 for python3.6

### DIFF
--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python: [3.6]
@@ -22,7 +22,7 @@ jobs:
       - name: Run Tox Tests
         run: "tox -e py"
   pep8:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup python


### PR DESCRIPTION
We still run our tests on python3.6 as openstack ussuri is still using 3.6. We can change this once we migrated to yoga.