### PR TITLE
WIP: Fix yoga tests

### DIFF
--- a/networking_ccloud/tests/unit/db/test_db_plugin.py
+++ b/networking_ccloud/tests/unit/db/test_db_plugin.py
@@ -21,6 +21,7 @@ from neutron.services.tag import tag_plugin
 from neutron.services.trunk import models as trunk_models
 from neutron.tests.unit.extensions import test_segment
 from neutron_lib import context
+from neutron_lib.plugins import directory
 from oslo_config import cfg
 
 from networking_ccloud.common.config import _override_driver_config, config_driver
@@ -33,6 +34,23 @@ from networking_ccloud.tests.common import config_fixtures as cfix
 class TestDBPluginNetworkSyncData(test_segment.SegmentTestCase, base.PortBindingHelper):
     def setUp(self):
         super().setUp()
+
+        cfg.CONF.set_override('global_physnet_mtu', 9000)
+        cfg.CONF.set_override('path_mtu', 9000, group='ml2')
+        cfg.CONF.set_override('network_vlan_ranges', ['foo:100:410', 'bar:200:210', 'baz:300:310',
+                                                      'spam:500:510', 'ham:600:610', 'mew:700:710',
+                                                      'caw:800:810'],
+                              group='ml2_type_vlan')
+        cfg.CONF.set_override('network_vlan_ranges', ['seagull:100:1010', 'crow:200:210', 'bgw1:234:244',
+                                                      'bgw2:345:355', 'transit1:111:121', 'transit2:222:233',
+                                                      'foo:100:410', 'bar:200:210', 'baz:300:310',
+                                                      'spam:500:510', 'ham:600:610', 'mew:700:710',
+                                                      'caw:800:810'],
+                              group='ml2_type_vlan')
+        plugin = directory.get_plugin()
+        vlan_type_driver = plugin.type_manager.drivers['vlan'].obj
+        vlan_type_driver._parse_network_vlan_ranges()
+        vlan_type_driver.update_network_segment_range_allocations()
 
         # network a, segments foo bar baz
         #   ports 1(foo), 2(foo), 3-bm(bar)

--- a/networking_ccloud/tests/unit/extensions/test_extensions.py
+++ b/networking_ccloud/tests/unit/extensions/test_extensions.py
@@ -117,7 +117,24 @@ class TestNetworkExtension(test_segment.SegmentTestCase, base.PortBindingHelper)
         self.db = CCDbPlugin()
         self.ctx = context.get_admin_context()
 
+        cfg.CONF.set_override('global_physnet_mtu', 9000)
+        cfg.CONF.set_override('path_mtu', 9000, group='ml2')
+        cfg.CONF.set_override('network_vlan_ranges', ['seagull:100:1010', 'crow:200:210', 'bgw1:234:244',
+                                                      'bgw2:345:355', 'transit1:111:121', 'transit2:222:233'],
+                              group='ml2_type_vlan')
+        cfg.CONF.set_override('network_vlan_ranges', ['seagull:100:1010', 'crow:200:210', 'bgw1:234:244',
+                                                      'bgw2:345:355', 'transit1:111:121', 'transit2:222:233',
+                                                      'foo:100:410', 'bar:200:210', 'baz:300:310',
+                                                      'spam:500:510', 'ham:600:610', 'mew:700:710',
+                                                      'caw:800:810'],
+                              group='ml2_type_vlan')
+        plugin = directory.get_plugin()
+        vlan_type_driver = plugin.type_manager.drivers['vlan'].obj
+        vlan_type_driver._parse_network_vlan_ranges()
+        vlan_type_driver.update_network_segment_range_allocations()
+
         self._net_a = self._make_network(name="a", admin_state_up=True, fmt='json')['network']
+        print(plugin.get_network(self.ctx, self._net_a['id']))
         for az in ('a', 'b'):
             self.db.ensure_bgw_for_network(self.ctx, self._net_a['id'], f"qa-de-1{az}")
             self.db.ensure_transit_for_network(self.ctx, self._net_a['id'], f"qa-de-1{az}")
@@ -215,13 +232,17 @@ class TestNetworkExtension(test_segment.SegmentTestCase, base.PortBindingHelper)
             self._make_segment(network_id=network_id, network_type='vxlan',
                                segmentation_id=424242,
                                tenant_id="test-tenant", fmt='json')['segment']
+            objs = self.ctx.session.query(segment_models.NetworkSegment).filter_by(physical_network=None,
+                                                                                   network_type='vxlan')
+            objs.update({'segment_index': 0})
 
             # make sure nothing is allocated
             self.assertEqual([], self.db.get_interconnects(self.ctx, network_id))
 
             # make apicall
             fake_new_segment = {'id': 'my-uuid', ml2_api.SEGMENTATION_ID: 1234}
-            with mock.patch.object(test_segment.SegmentTestPlugin, 'type_manager', create=True) as mock_tm, \
+            plugin = directory.get_plugin()
+            with mock.patch.object(plugin, 'type_manager', create=True) as mock_tm, \
                     mock.patch.object(CCFabricSwitchAgentRPCClient, 'apply_config_update') as mock_acu:
                 mock_tm.allocate_dynamic_segment.return_value = fake_new_segment
                 self.app.put(f"/cc-fabric/networks/{network_id}/ensure_interconnects")

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.2.0
-envlist = py36,pep8
+envlist = py38,pep8
 skipsdist = True
 ignore_basepython_conflict = true
 
@@ -13,10 +13,12 @@ setenv =
    OS_STDOUT_CAPTURE=1
    OS_STDERR_CAPTURE=1
    OS_TEST_TIMEOUT=60
-deps = -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/ussuri}
+deps = -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/yoga}
        -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-commands = stestr run {posargs}
+commands =
+    pip install -U pip
+    stestr run {posargs}
 
 [testenv:lower-constraints]
 deps = -c{toxinidir}/lower-constraints.txt


### PR DESCRIPTION
We need to configure MTUs, as else the networks are not getting created. The default MTU is 1500, for the VXLAN segment OpenStack substracts space for the header and our standard networks cannot be created anymore. Therefore I'm hardcoding the MTU in the tests.

Network segments need to be specified for the current allocation logic. Sadly we have a clash between two SegmentTestCases, where they both reconfigure the same DB. I've just put the same ranges into both cases, but a real fix would need separate DBs for both tests. This is why this commit is still WIP.

---

DO NOT MERGE, I'll to a proper one after my vacation.