### PR TITLE
Fix yoga tests

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - stable/ussuri-m3
+      - stable/yoga-m3
   pull_request:
 
 jobs:
@@ -24,7 +24,7 @@ jobs:
         run: tox -e docs
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/stable/ussuri-m3' }}
+        if: ${{ github.ref == 'refs/heads/stable/yoga-m3' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./doc/build/html

--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -3,14 +3,14 @@ on:
   push:
     branches:
       - main
-      - stable/ussuri-m3
+      - stable/yoga-m3
   pull_request:
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6]
+        python: [3.8]
     steps:
       - uses: actions/checkout@v2
       - name: Setup python
@@ -22,13 +22,13 @@ jobs:
       - name: Run Tox Tests
         run: "tox -e py"
   pep8:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.8
       - name: Install Tox
         run: pip install tox
       - name: Run Tox pep8

--- a/networking_ccloud/tests/base.py
+++ b/networking_ccloud/tests/base.py
@@ -34,7 +34,7 @@ class TestCase(base.BaseTestCase):
         config.setup_logging()
 
 
-class PortBindingHelper():
+class PortBindingHelper:
     def _make_port_with_binding(self, segments, host, **kwargs):
         kwargs['binding:host_id'] = host
         profile = kwargs.pop('profile', None)

--- a/networking_ccloud/tests/base.py
+++ b/networking_ccloud/tests/base.py
@@ -19,7 +19,7 @@ import json
 from neutron.common import config
 from neutron.plugins.ml2 import models as ml2_models
 from neutron_lib import context
-from oslo_config import cfg
+from oslo_config import cfg, fixture as config_fixture
 from oslotest import base
 
 
@@ -27,6 +27,8 @@ class TestCase(base.BaseTestCase):
     """Test case base class for all unit tests."""
 
     def setUp(self):
+        self.useFixture(config_fixture.Config())
+
         super().setUp()
 
         # configure debug logging (see also neutron.tests.base setup_test_logging())

--- a/networking_ccloud/tests/unit/common/test_config_validation.py
+++ b/networking_ccloud/tests/unit/common/test_config_validation.py
@@ -29,13 +29,11 @@ class TestConfigValidation(base.TestCase):
         super().setUp()
 
     def test_validate_ml2_vlan_ranges_success(self):
-        cfg.CONF.set_override('tenant_network_types', ['vxlan', 'vlan'], group='ml2')
         cfg.CONF.set_override('network_vlan_ranges', ['seagull:23:42', 'cat:53:1337'], group='ml2_type_vlan')
         cfg.CONF.set_override('driver_config_path', 'invalid/path/to/conf.yaml', group='ml2_cc_fabric')
         validate_ml2_vlan_ranges(self.conf_drv)
 
     def test_validate_ml2_vlan_ranges_failure(self):
-        cfg.CONF.set_override('tenant_network_types', ['vxlan', 'vlan'], group='ml2')
         cfg.CONF.set_override('network_vlan_ranges', ['cat:53:1337'], group='ml2_type_vlan')
         cfg.CONF.set_override('driver_config_path', 'invalid/path/to/conf.yaml', group='ml2_cc_fabric')
         self.assertRaisesRegex(cc_exc.MissingPhysnetsInNeutronConfig, ".*seagull.*",

--- a/networking_ccloud/tests/unit/db/test_db_plugin.py
+++ b/networking_ccloud/tests/unit/db/test_db_plugin.py
@@ -31,7 +31,7 @@ from networking_ccloud.tests import base
 from networking_ccloud.tests.common import config_fixtures as cfix
 
 
-class TestDBPluginNetworkSyncData(test_segment.SegmentTestCase, base.PortBindingHelper):
+class TestDBPluginNetworkSyncData(test_segment.SegmentTestCase, base.PortBindingHelper, base.TestCase):
     def setUp(self):
         super().setUp()
 
@@ -301,7 +301,7 @@ class TestDBPluginNetworkSyncData(test_segment.SegmentTestCase, base.PortBinding
             self._db.get_subnetpool_details(ctx, [self._subnetpool_reg['id'], self._subnetpool_az['id']]))
 
 
-class TestNetworkInterconnectAllocation(test_segment.SegmentTestCase, base.PortBindingHelper):
+class TestNetworkInterconnectAllocation(test_segment.SegmentTestCase, base.PortBindingHelper, base.TestCase):
     def setUp(self):
         super().setUp()
 

--- a/networking_ccloud/tests/unit/extensions/test_extensions.py
+++ b/networking_ccloud/tests/unit/extensions/test_extensions.py
@@ -76,7 +76,7 @@ class TestSyncExtension(base.TestCase):
         self.assertEqual({'driver_reached': True}, resp.json)
 
 
-class TestNetworkExtension(test_segment.SegmentTestCase, base.PortBindingHelper):
+class TestNetworkExtension(test_segment.SegmentTestCase, base.PortBindingHelper, base.TestCase):
     def setUp(self):
         super().setUp()
         directory.add_plugin(tagging.TAG_PLUGIN_TYPE, tag_plugin.TagPlugin())

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.2.0
 envlist = py38,pep8
-skipsdist = True
+skipsdist = False
 ignore_basepython_conflict = true
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.2.0
-envlist = py36,pep8
+envlist = py38,pep8
 skipsdist = True
 ignore_basepython_conflict = true
 
@@ -13,10 +13,12 @@ setenv =
    OS_STDOUT_CAPTURE=1
    OS_STDERR_CAPTURE=1
    OS_TEST_TIMEOUT=60
-deps = -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/ussuri}
+deps = -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/yoga}
        -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-commands = stestr run {posargs}
+commands =
+    pip install -U pip
+    stestr run {posargs}
 
 [testenv:lower-constraints]
 deps = -c{toxinidir}/lower-constraints.txt


### PR DESCRIPTION
We need to configure MTUs, as else the networks are not getting created. The default MTU is 1500, for the VXLAN segment OpenStack substracts space for the header and our standard networks cannot be created anymore. Therefore I'm hardcoding the MTU in the tests.

Network segments need to be specified for the current allocation logic.

oslo.config's set_override() seems to not be cleaned up after a test is run. This means override of one test can influence tests run after this test. To avoid this we needed to add some cleanup statements for tenant_network_types. Before this commit the problematic behavior could be triggered with this command:

tox -e py38 -- --serial TestConfigValidation.test_validate_ml2_vlan_ranges_success networking_ccloud.tests.unit.db.test_db_plugin.TestDBPluginNetworkSyncData.test_get_hosts_on_segments_with_segment_with_wrong_level