### PR TITLE
Use the "connectivity" property of "MechanismDriver" for l2 connectivity support

### DIFF
--- a/networking_ccloud/ml2/mech_driver.py
+++ b/networking_ccloud/ml2/mech_driver.py
@@ -65,7 +65,7 @@ class CCFabricMechanismDriver(ml2_api.MechanismDriver, CCFabricDriverAPI):
 
         self.vif_details = {
             # allow ports without an IP to be bound
-            pb_api.VIF_DETAILS_CONNECTIVITY: pb_api.CONNECTIVITY_L2,
+            pb_api.VIF_DETAILS_CONNECTIVITY: self.connectivity,
         }
 
     def initialize(self):
@@ -93,6 +93,10 @@ class CCFabricMechanismDriver(ml2_api.MechanismDriver, CCFabricDriverAPI):
         if self._plugin_property is None:
             self._plugin_property = directory.get_plugin()
         return self._plugin_property
+
+    @property
+    def connectivity(self):
+        return pb_api.CONNECTIVITY_L2
 
     def start_rpc_listeners(self):
         """Start the RPC listeners.


### PR DESCRIPTION
Adapation of https://opendev.org/openstack/neutron/commit/0fe6c0b8ca8a5704242766472d94d5ca86832363
for 3rd party drivers.

The base class "MechanismDriver" now has a property called
"connectivity". This patch overrides the default value in the out-of-tree drivers.

The method "_check_drivers_connectivity" now uses this property
that is available in all drivers.
