### PR TITLE
Fix TypeError on missing network in update_port_postcommit()

### DIFF
--- a/networking_ccloud/ml2/mech_driver.py
+++ b/networking_ccloud/ml2/mech_driver.py
@@ -543,10 +543,20 @@ class CCFabricMechanismDriver(ml2_api.MechanismDriver, CCFabricDriverAPI):
                 LOG.debug("Port %s does not have two binding levels, no update will be sent. Old host %s, levels %s",
                           context.current['id'], old_host, context.original_binding_levels)
                 return
+            orig_network_id = None
+            if context.network.original is not None:
+                orig_network_id = context.network.original['id']
+            elif 'network_id' in context.original_binding_levels[1][ml2_api.BOUND_SEGMENT]:
+                orig_network_id = context.original_binding_levels[1][ml2_api.BOUND_SEGMENT]['network_id']
+            else:
+                LOG.warning("Port %s transitioning from %s to %s does not have an original network attached to it, "
+                            "old host will not be cleaned up",
+                            context.current['id'], old_host, new_host)
+                return
             self.driver_handle_binding_host_removed(context._plugin_context, context, context.original,
                                                     context.original_binding_levels[0][ml2_api.BOUND_SEGMENT],
                                                     context.original_binding_levels[1][ml2_api.BOUND_SEGMENT],
-                                                    context.network.original['id'])
+                                                    orig_network_id)
 
     def delete_port_postcommit(self, context):
         """Delete a port.


### PR DESCRIPTION
When a port is updated we try to clean up after it. As there is no explicit delete message, but only a update_port_postcommit() call, we handle deletion of the old host. For this, the delete call also needs the network, but in certain scenarios, there is no original network - most likely in cases where the port only gets its binding host updated, but stays in the same network. Therefore in these cases we now use the network_id given in the original bindings level. As segments are not always fully specified (or better: this is what I have seen in some places in the code, but am unsure if the segments are always fully specified or not within a NetworkContext (fully specified in this case means "missing the network_id entry")), I chose the "safe way", using the original network first, then look at the segment dict and if that fails we log a warning and return, i.e. don't try to clean up after the segment.

This fixes a TypeError, where when there was no original network, we'd try to lookup ['id'] to the original network, which was None.