### PR TITLE
Netbox 3.0 adjustments

### DIFF
--- a/networking_ccloud/tools/netbox_config_gen.py
+++ b/networking_ccloud/tools/netbox_config_gen.py
@@ -382,15 +382,6 @@ class ConfigGenerator:
                 extra_vlans.add(vlan.vid)
                 continue
 
-            # by convention we ignore certain VLAN groups member VLANs, once we upgrade to netbox 3.x we shall remove
-            # this as VLAN groups will then support tags
-            if vlan.group and (
-                    (vlan.group.slug.startswith(self.region) and vlan.group.slug.endswith('cp'))
-                    or vlan.group.slug == f'{self.region}-regional'
-                    or vlan.group.slug == 'global-cc-core-transit'):
-                extra_vlans.add(vlan.vid)
-                continue
-
             mandatory_attrs = ('vid', 'tenant')
             for attr in mandatory_attrs:
                 if not getattr(vlan, attr, None):


### PR DESCRIPTION
With netbox 3.0, there were 2 API changes that affect us:
1. Interfaces can now carry multiple connections, I believe is that is
   to support broken out interfaces. We do not plan to have break outs
   in the future, however we have them now. Yet we model them in the
   form that we create a new interface (which could carry individual
   VLANs and so on) and then model the connection. Hence, there is no
   need for us to support multiple connected endpoints under an
   interface. If we encounter it, we fail.

2. Sites can have multiple ASNs now, ASNs are objects, not plain ints
   anymore. This is not an issue so far as a site currently only carries
   one ASN, which we simply unpack. Yet, I can imagine that we use
   multiple ASN in a site in the future in which case we would currently
   throw an exceptions. That's fine for now. If the time comes, we
   probably need to tag the ASN we want to use for the fabric.
