### PR TITLE
[config-gen] Trust apod and swift nodes' interface VLANs

### DIFF
--- a/networking_ccloud/tools/netbox_config_gen.py
+++ b/networking_ccloud/tools/netbox_config_gen.py
@@ -489,7 +489,7 @@ class ConfigGenerator:
 
     def get_asn_region(self, region):
         sites = self.netbox.dcim.sites.filter(region=region)
-        site_asns = {asn for site in sites if site.asns for asn in site.asns}
+        site_asns = {asn.asn for site in sites if site.asns for asn in site.asns}
         if not site_asns:
             raise ConfigException(f"Region {region} has no ASN")
         if len(site_asns) > 1:
@@ -581,7 +581,7 @@ class ConfigGenerator:
                     raise ConfigException(f'Interface {iface.name} on {switch.name} has more than one '
                                           'connected endpoint')
 
-                far_interface = iface.connected_endpoint[0]
+                far_interface = iface.connected_endpoints[0]
                 far_device = far_interface.device
                 if far_device.device_role.slug not in self.connection_roles:
                     continue


### PR DESCRIPTION
When generating the config, we usually only pickup extra-vlans from the
switch side, not from the host side. That is, as the device side is
modelled by the device owners, yet the switch side is modelled by us.
However, we have agreed that for future VLAN assignments, the device
side modelling of apod nodes and swift devices will be modelled by their
team. Any VLAN updates will hence propagate to the driver config.