### PR TITLE
Only consider own subports for trunking

### DIFF
--- a/networking_ccloud/db/db_plugin.py
+++ b/networking_ccloud/db/db_plugin.py
@@ -80,7 +80,9 @@ class CCDbPlugin(db_base_plugin_v2.NeutronDbPluginV2,
         query = query.join(segment_models.NetworkSegment,
                            ml2_models.PortBindingLevel.segment_id == segment_models.NetworkSegment.id)
         query = query.outerjoin(trunk_models.SubPort,
-                                trunk_models.SubPort.port_id == ml2_models.PortBinding.port_id)
+                                sa.and_(trunk_models.SubPort.port_id == ml2_models.PortBinding.port_id,
+                                        ml2_models.PortBinding.vif_type == cc_const.VIF_TYPE_CC_FABRIC))
+
         if level is not None:
             query = query.filter(ml2_models.PortBindingLevel.level == level)
         if driver is not None:


### PR DESCRIPTION
When querying segment info from the DB we also query out the trunk id for subports. Trunking for the OpenStack trunking extension always needs to happen at the last driver, so in this case we must ignore subports that belong to other drivers. We will only handle trunking for our own ports, this being ports that are bound by us as the last driver. We identify these ports by their vif_type, cc-fabric.