### PR TITLE
Allow hostgroups to bind multiple trunks w/ config

### DIFF
--- a/networking_ccloud/common/config/config_driver.py
+++ b/networking_ccloud/common/config/config_driver.py
@@ -302,6 +302,10 @@ class Hostgroup(pydantic.BaseModel):
     # vlans that are added to all allowed-vlan list without managing the vlan on switch
     extra_vlans: List[pydantic.conint(gt=1, lt=4095)] = None
 
+    # allow multiple trunks per hostgroup, not setting the native vlan then (direct bindings only)
+    # note that this means that no native vlan will be set for ports in this hostgroup, ever
+    allow_multiple_trunk_ports: bool = False
+
     _vlan_pool: str = None
 
     class Config:
@@ -346,6 +350,12 @@ class Hostgroup(pydantic.BaseModel):
     def ensure_hostgroups_with_role_are_direct_binding(cls, values):
         if values.get('role') and not values.get('direct_binding'):
             raise ValueError("Hostgroups for bgws/tranits need to be direct bindings")
+        return values
+
+    @pydantic.root_validator
+    def ensure_allow_multiple_trunk_ports_are_direct_binding(cls, values):
+        if values.get('allow_multiple_trunk_ports') and not values.get('direct_binding'):
+            raise ValueError("allow_multiple_trunk_ports can only be set for direct binding hostgroups")
         return values
 
     @pydantic.root_validator

--- a/networking_ccloud/ml2/agent/common/messages.py
+++ b/networking_ccloud/ml2/agent/common/messages.py
@@ -424,7 +424,7 @@ class SwitchConfigUpdateList:
                     if hg_config.direct_binding and not hg_config.role:
                         if trunk_vlan:
                             iface.add_vlan_translation(seg_vlan, trunk_vlan)
-                        else:
+                        elif not hg_config.allow_multiple_trunk_ports:
                             iface.native_vlan = seg_vlan
 
     def add_vrf_bgp_config(self, switch_names, vrf_name, vrf_networks, vrf_aggregates):

--- a/networking_ccloud/services/trunk/driver.py
+++ b/networking_ccloud/services/trunk/driver.py
@@ -115,8 +115,12 @@ class CCTrunkDriver(base.DriverBase):
         trunks_on_host = self.fabric_plugin.get_trunks_with_binding_host(context, trunk_host)
         trunks = set(trunks_on_host) - set([trunk.id])
         if trunks:
-            raise BadTrunkRequest(trunk_port_id=trunk.port_id,
-                                  reason=f"Host {trunk_host} already has trunk {' '.join(trunks)} connected to it")
+            if hg_config.allow_multiple_trunk_ports:
+                LOG.info("Creating extra trunk on %s, as allowed by hostgroup (existing trunks: %s)",
+                         trunk_host, ", ".join(trunks_on_host))
+            else:
+                raise BadTrunkRequest(trunk_port_id=trunk.port_id,
+                                      reason=f"Host {trunk_host} already has trunk {' '.join(trunks)} connected to it")
 
         # subport validation
         parent_hg = hg_config.get_parent_metagroup(self.drv_conf)

--- a/networking_ccloud/tests/unit/common/test_driver_config.py
+++ b/networking_ccloud/tests/unit/common/test_driver_config.py
@@ -116,6 +116,19 @@ class TestDriverConfigValidation(base.TestCase):
                                config.Hostgroup, binding_hosts=["seagull-compute"],
                                members=[config.SwitchPort(switch="seagull-sw1")])
 
+    def test_hostgroup_multi_trunk_requires_direct_binding(self):
+        # should work
+        hg = config.Hostgroup(binding_hosts=["node001-seagull"],
+                              members=[config.SwitchPort(switch="seagull-sw1", name="e1/1/1")],
+                              allow_multiple_trunk_ports=True)
+        self.assertTrue(hg.allow_multiple_trunk_ports)
+
+        # should fail
+        self.assertRaisesRegex(ValueError, "can only be set for direct binding hostgroups",
+                               config.Hostgroup, binding_hosts=["seagull-compute"],
+                               members=["node001-seagull"], metagroup=True,
+                               allow_multiple_trunk_ports=True)
+
     def test_global_default_vlan_ranges(self):
         self.assertRaisesRegex(ValueError, ".*not in format.*", config.GlobalConfig, asn_region=65000,
                                default_vlan_ranges=["foo:bar"], availability_zones=[])

--- a/networking_ccloud/tools/netbox_config_gen.py
+++ b/networking_ccloud/tools/netbox_config_gen.py
@@ -611,7 +611,8 @@ class ConfigGenerator:
 
         hgs = [conf.Hostgroup(binding_hosts=[h.name], direct_binding=True, members=self.sort_switchports(m),
                               infra_networks=sorted(device_infra_nets_map[h][0], key=lambda x: x.vlan),
-                              extra_vlans=sorted(device_infra_nets_map[h][1]) if device_infra_nets_map[h][1] else None)
+                              extra_vlans=sorted(device_infra_nets_map[h][1]) if device_infra_nets_map[h][1] else None,
+                              allow_multiple_trunk_ports=h.device_role.slug == 'dp-data-domain')
                for h, m in device_ports_map.items()]
         return set(device_ports_map.keys()), hgs
 


### PR DESCRIPTION
If a hostgroup has allow_multiple_trunk_ports set it can now have multiple trunks on it. This allows us to have multiple domains/projects set VLAN translations for the same device without the networks needing to be shared in to the same project. As we don't know in this case which port should dictate the native VLAN we don't set the native VLAN at all for these groups.

---
Now also with the part that handles config generation!