### PR TITLE
Make port speed configurable (in EOS as well)

### DIFF
--- a/networking_ccloud/common/config/config_driver.py
+++ b/networking_ccloud/common/config/config_driver.py
@@ -189,6 +189,9 @@ class SwitchPort(pydantic.BaseModel):
     members: List[str] = None
     unmanaged: bool = False
 
+    # set interface (or member interface) speed to this vendor specific value
+    speed: str = None
+
     @pydantic.root_validator
     def only_allow_members_and_pc_id_with_lacp_enabled(cls, v):
         if v['members'] and not v['lacp']:

--- a/networking_ccloud/ml2/agent/common/messages.py
+++ b/networking_ccloud/ml2/agent/common/messages.py
@@ -230,6 +230,7 @@ class IfaceConfig(pydantic.BaseModel):
     vlan_translations: List[VlanTranslation] = None
     portchannel_id: pydantic.conint(gt=0) = None
     members: List[str] = None
+    speed: str = None
 
     def __lt__(self, other):
         return self.name < other.name
@@ -244,7 +245,7 @@ class IfaceConfig(pydantic.BaseModel):
 
     @classmethod
     def from_switchport(cls, switchport):
-        iface = cls(name=switchport.name)
+        iface = cls(name=switchport.name, speed=switchport.speed)
         if switchport.lacp:
             iface.portchannel_id = switchport.portchannel_id
             iface.members = switchport.members

--- a/networking_ccloud/ml2/agent/eos/switch.py
+++ b/networking_ccloud/ml2/agent/eos/switch.py
@@ -832,6 +832,15 @@ class EOSSwitch(SwitchBase):
                         data['switched-vlan'] = switched_vlan_config
                     if iface.vlan_translations:
                         remove_stale_vlan_translations(iface_name, iface, is_pc=False)
+                    if iface.speed:
+                        if iface.speed in ('1g', '10g', '25g', '40g', '100g', '400g'):
+                            eth_config = data.setdefault('config', {})
+                            eth_config['port-speed'] = f"SPEED_{iface.speed.upper()}B"
+                            eth_config['auto-negotiate'] = False
+                            eth_config['duplex-mode'] = 'FULL'
+                        else:
+                            LOG.warning('Invalid interface speed "%s" for interface %s, ignoring it',
+                                        iface.speed, iface.name)
                     iface_cfg = (EOSGNMIPaths.IFACE_ETH.format(iface=iface_name), data)
                     config_req.get_list(operation).append(iface_cfg)
         else:


### PR DESCRIPTION
As the driver is fully responsible for its own switchports, we use a replace config call via GNMI to configure those ports. This means that there is - at the moment - no option for manual configuration of these interfaces. This means that we now also need to be able to configure interface port speeds.

Config-wise this means that we just have a string, which might be vendor-specific, but at least understandable by the platform's agent. In the eos case we translate speeds like 10/100g to their respective API values (SPEED_10GB, SPEED_100GB).