### PR TITLE
Support loading credentials from extra file

### DIFF
--- a/networking_ccloud/common/config/__init__.py
+++ b/networking_ccloud/common/config/__init__.py
@@ -16,7 +16,7 @@ from neutron_lib.plugins import utils as plugin_utils
 from oslo_config import cfg
 import yaml
 
-from networking_ccloud.common.config.config_driver import DriverConfig
+from networking_ccloud.common.config.config_driver import DriverConfig, DriverCredentials
 from networking_ccloud.common.config import config_oslo  # noqa: F401
 from networking_ccloud.common import exceptions as cc_exc
 _FABRIC_CONF = None
@@ -50,6 +50,18 @@ def get_driver_config(path=None, cached=True):
         # FIXME: error handling
         with open(path) as f:
             conf_data = yaml.safe_load(f)
+
+        if cfg.CONF.ml2_cc_fabric.driver_config_credentials_path:
+            with open(cfg.CONF.ml2_cc_fabric.driver_config_credentials_path) as f:
+                creds_data = yaml.safe_load(f)
+                creds = DriverCredentials.parse_obj(creds_data)
+            if creds.switch_credentials:
+                for sg in conf_data.get('switchgroups', []):
+                    for sw in sg.get('members'):
+                        cred = creds.switch_credentials.get(sw.get('name'))
+                        if cred:
+                            sw['user'] = cred.user
+                            sw['password'] = cred.password
 
         # FIXME: error handling
         _FABRIC_CONF = DriverConfig.parse_obj(conf_data)

--- a/networking_ccloud/common/config/config_driver.py
+++ b/networking_ccloud/common/config/config_driver.py
@@ -756,3 +756,12 @@ class DriverConfig(pydantic.BaseModel):
 
     def list_availability_zones(self):
         return sorted(az.name for az in self.global_config.availability_zones)
+
+
+class Credentials(pydantic.BaseModel):
+    user: str
+    password: str
+
+
+class DriverCredentials(pydantic.BaseModel):
+    switch_credentials: Dict[str, Credentials] = None

--- a/networking_ccloud/common/config/config_oslo.py
+++ b/networking_ccloud/common/config/config_oslo.py
@@ -21,6 +21,8 @@ LOG = logging.getLogger(__name__)
 cc_fabric_opts = [
     cfg.StrOpt("driver_config_path",
                help="Path to yaml config file"),
+    cfg.StrOpt("driver_config_credentials_path",
+               help="Extra config file to store crendentials in. The driver config will be updated with "),
     cfg.BoolOpt("handle_all_l3_gateways", default=True,
                 help="Spawn l3 gateways for all external networks. If this is disabled only networks with "
                      "the tag 'gateway-host::cc-fabric' will be considered"),

--- a/networking_ccloud/tests/unit/common/test_driver_config.py
+++ b/networking_ccloud/tests/unit/common/test_driver_config.py
@@ -12,7 +12,13 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from networking_ccloud.common.config import _override_driver_config
+import copy
+import json
+import tempfile
+
+from oslo_config import cfg
+
+from networking_ccloud.common.config import _override_driver_config, get_driver_config
 from networking_ccloud.common.config import config_driver as config
 from networking_ccloud.common import constants as cc_const
 from networking_ccloud.tests import base
@@ -292,3 +298,60 @@ class TestDriverConfig(base.TestCase):
         self.assertEqual({2000, 2001, 2002}, sgs[0].get_managed_vlans(drv_conf, with_infra_nets=False))
         self.assertEqual({42, 2000, 2001, 2002}, sgs[0].get_managed_vlans(drv_conf, with_infra_nets=True))
         self.assertEqual({1337, 1338, 1339, 3333}, sgs[1].get_managed_vlans(drv_conf, with_infra_nets=False))
+
+
+class TestDriverConfigLoading(base.TestCase):
+    def setUp(self):
+        super().setUp()
+        switchgroups = [
+            cfix.make_switchgroup("seagull", availability_zone="qa-de-1a"),
+            cfix.make_switchgroup("crow", availability_zone="qa-de-1b"),
+            cfix.make_switchgroup("bgw2", availability_zone="qa-de-1b"),
+        ]
+        hg_seagull = cfix.make_metagroup("seagull")
+        hg_crow = cfix.make_hostgroups("crow")
+        hostgroups = hg_seagull + hg_crow
+
+        self.drv_conf = cfix.make_config(switchgroups=switchgroups, hostgroups=hostgroups)
+        self.drv_conf_data = self.drv_conf.dict(exclude_unset=True, exclude_defaults=True)
+
+    def test_config_loading(self):
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write(json.dumps(self.drv_conf_data))
+            f.close()
+            c = get_driver_config(f.name, cached=False)
+        self.assertEqual(3, len(c.switchgroups))
+
+    def test_credentials_loading(self):
+        drv_conf_data = copy.deepcopy(self.drv_conf_data)
+        for sg in drv_conf_data['switchgroups']:
+            for sw in sg['members']:
+                del sw['user']
+                del sw['password']
+
+        creds = {
+            "seagull-sw1": {"user": "herring-gull", "password": "fries"},
+            "seagull-sw2": {"user": "mew-gull", "password": "fish"},
+            "crow-sw1": {"user": "hooded-crow", "password": "walnut"},
+            "crow-sw2": {"user": "rook", "password": "seeds"},
+            "bgw2-sw1": {"user": "weesiknich", "password": "weesikochnich"},
+            "bgw2-sw2": {"user": "watsolls", "password": "bestimmtwatjutes"},
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f, \
+                tempfile.NamedTemporaryFile(mode="w", delete=False) as creds_file:
+            f.write(json.dumps(drv_conf_data))
+            f.close()
+            creds_file.write(json.dumps({"switch_credentials": creds}))
+            creds_file.close()
+            cfg.CONF.set_override('driver_config_credentials_path', creds_file.name, group='ml2_cc_fabric')
+            c = get_driver_config(f.name, cached=False)
+        self.assertEqual(3, len(c.switchgroups))
+
+        checked_switches = set()
+        for sg in c.switchgroups:
+            for sw in sg.members:
+                self.assertEqual(creds[sw.name], dict(user=sw.user, password=sw.password))
+                checked_switches.add(sw.name)
+
+        self.assertEqual(set(creds), checked_switches)

--- a/networking_ccloud/tests/unit/tools/test_config_check.py
+++ b/networking_ccloud/tests/unit/tools/test_config_check.py
@@ -12,7 +12,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import tempfile
 from unittest import mock
+
+import yaml
 
 from networking_ccloud.tests import base
 from networking_ccloud.tools import config_check
@@ -28,3 +31,28 @@ class TestConfigValidationTool(base.TestCase):
         args = ["cc-config-check", "-y", "examples/cc-driver-config.yaml"]
         with mock.patch('sys.argv', args):
             config_check.main()
+
+    def test_validation_with_credentials_file(self):
+        drv_conf = yaml.safe_load(open("examples/cc-driver-config.yaml"))
+        for sg in drv_conf['switchgroups']:
+            for sw in sg['members']:
+                del sw['user']
+                del sw['password']
+
+        creds_conf = {
+            "switch_credentials": {
+                "qa-de-3-sw1111a-bb206": {"user": "cat", "password": "meow"},
+                "qa-de-3-sw1111b-bb206": {"user": "cat", "password": "meow"},
+            },
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as conf_file, \
+                tempfile.NamedTemporaryFile(mode="w", delete=False) as creds_file:
+            conf_file.write(yaml.dump(drv_conf))
+            conf_file.close()
+            creds_file.write(yaml.dump(creds_conf))
+            creds_file.close()
+
+            args = ["cc-config-check", "-y", conf_file.name, "--credentials-file", creds_file.name]
+            with mock.patch('sys.argv', args):
+                config_check.main()

--- a/networking_ccloud/tools/config_check.py
+++ b/networking_ccloud/tools/config_check.py
@@ -28,13 +28,14 @@ def main():
     )
     parser.add_argument("-c", "--config-file")
     parser.add_argument("-y", "--yaml-file")
+    parser.add_argument("--credentials-file")
 
     args = parser.parse_args()
 
     if not (args.config_file or args.yaml_file):
         parser.error("Please specify either a config file or a yaml file to check")
-    elif args.config_file and args.yaml_file:
-        parser.error("Config file and yaml file checks via cli are mutually exclusive")
+    elif args.config_file and (args.yaml_file or args.credentials_file):
+        parser.error("Config file and yaml file / credentials file checks via cli are mutually exclusive")
 
     if args.config_file:
         # register necessary opts by importing our olso config
@@ -48,6 +49,9 @@ def main():
             sys.exit(1)
 
         print("OK - oslo.config could load driver config")
+
+    if args.credentials_file:
+        cfg.CONF.set_override('driver_config_credentials_path', args.credentials_file, group='ml2_cc_fabric')
 
     # load yaml config (either via oslo config (args.yaml_file is None) or via path)
     drv_conf = get_driver_config(path=args.yaml_file, cached=False)

--- a/networking_ccloud/tools/netbox_config_gen.py
+++ b/networking_ccloud/tools/netbox_config_gen.py
@@ -816,10 +816,17 @@ class ConfigGenerator:
         if minimum_common_extra_vlans:
             metagroup.extra_vlans = sorted(minimum_common_extra_vlans)
 
-    def generate_config(self):
+    def generate_config(self, use_dummy_credentials: bool = False):
 
-        switch_user = self.args.switch_user
-        switch_password = self.args.switch_password
+        # We cannot instantiate a conf.Switch without user and password, hence remove dummies that we
+        # drop later in the raw dict
+        if use_dummy_credentials:
+            switch_user = 'DUMMY_USER'
+            switch_password = 'DUMMY_PASSWORD'
+        else:
+            switch_user = self.args.switch_user
+            switch_password = self.args.switch_password
+
         address_scope_vrf_maps_path = self.args.address_scope_vrf_map
 
         nb_switches = list(self.switch_filter(self.netbox.dcim.devices.filter(region=self.region, role=self.leaf_role,
@@ -861,6 +868,25 @@ class ConfigGenerator:
 
         return config
 
+    def generate_credentials(self, sgs: List[conf.SwitchGroup],
+                             switch_user: str, switch_password: str) -> conf.DriverCredentials:
+        credentials: Dict[str, conf.Credentials] = {}
+        for sg in sgs:
+            for switch in sg.members:
+                credentials[switch.name] = conf.Credentials(user=switch_user, password=switch_password)
+        return conf.DriverCredentials(switch_credentials=credentials)
+
+    def sanitize_conf_data(self, conf_data: Dict[str, Any]):
+        for sg in conf_data['switchgroups']:
+            for member in sg['members']:
+                del member['user']
+                del member['password']
+
+    def wrap_dict(self, data: Dict[str, Any], path: List[str]) -> Dict[str, Any]:
+        for key in reversed(path):
+            data = {key: data}
+        return data
+
     def do_sanity_check(self, config):
         # FIXME: after config has been created, load it with the normal driver verification stuff
         pass
@@ -876,9 +902,13 @@ def main():
     parser.add_argument("-p", "--switch-password", help="Default switch password")
     parser.add_argument('-V', '--vault-ref',
                         help="Instead of a password, use this vault references, formatted like <path>:<field>")
-
-    parser.add_argument('-w', '--wrap-in', help='Keys under which the generated config should be nested under. '
-                                                'Format should be: <key1>/<key2>...')
+    parser.add_argument('-c', "--credential-file",
+                        help="Path for a file containing switch credentials. If this is set, all credentials will be "
+                             "removed from the generated config and persisted in this file instead.")
+    parser.add_argument('--wrap-config-in', help='Keys under which the generated config should be nested under. '
+                                                 'Format should be: <key1>/<key2>...')
+    parser.add_argument('--wrap-credentials-in', help='Keys under which the generated credentials should be nested. '
+                        'Same as --wrap-config-in')
     parser.add_argument("-a", "--address-scope-vrf-map", type=Path, nargs="+",
                         help="Path to file containing a mapping of address scope names to VRFs. If this is omitted, "
                              "no mapping will be generated.")
@@ -900,25 +930,43 @@ def main():
         else:
             parser.error(f'Invalid vault reference should be <path>:<field>, got {args.vault_ref}')
 
-    if args.wrap_in:
-        m = re.match(r'^(?:\w+/)*(?:\w+)$', args.wrap_in)
+    for wrap_in in [args.wrap_config_in, args.wrap_credentials_in]:
+        if not wrap_in:
+            continue
+        m = re.match(r'^(?:\w+/)*(?:\w+)$', wrap_in)
         if not m:
-            parser.error(f'Invalid format for --wrap-in. Should be like <key1>/<key2>..., got {args.wrap_in}')
+            parser.error('Invalid format for --wrap-config-in or --wrap-credentials-in. '
+                         f'Should be like <key1>/<key2>..., got {wrap_in}')
 
     cfggen = ConfigGenerator(args.region, args, args.verbose)
-    cfg = cfggen.generate_config()
+    cfg = cfggen.generate_config(use_dummy_credentials=bool(args.credential_file))
+
+    if args.credential_file:
+        credentials = cfggen.generate_credentials(cfg.switchgroups, args.switch_user, args.switch_password)
+        cred_data = credentials.dict()
+        if args.wrap_credentials_in:
+            cred_data = cfggen.wrap_dict(cred_data, args.wrap_credentials_in.split('/'))
+        with open(args.credential_file, "w") as f:
+            yaml_data = yaml.safe_dump(cred_data)
+            if args.vault_ref:
+                yaml_data = yaml_data.replace(VAULT_REF_REPLACEMENT,
+                                              f'*vault(path: {vault_path}, field: {vault_field})')  # type: ignore
+            f.write(yaml_data)
 
     if args.output:
         conf_data = cfg.dict(exclude_unset=True, exclude_defaults=True, exclude_none=True)
 
-        if args.wrap_in:
-            for k in reversed(args.wrap_in.split('/')):
-                conf_data = {k: conf_data}
+        if args.credential_file:
+            cfggen.sanitize_conf_data(conf_data)
+
+        if args.wrap_config_in:
+            conf_data = cfggen.wrap_dict(conf_data, args.wrap_config_in.split('/'))
 
         yaml_data = yaml.safe_dump(conf_data)
-        if args.vault_ref:
+        if args.vault_ref and not args.credential_file:
             yaml_data = yaml_data.replace(VAULT_REF_REPLACEMENT,
                                           f'*vault(path: {vault_path}, field: {vault_field})')  # type: ignore
+
         if args.output == '-':
             print(yaml_data)
         else:


### PR DESCRIPTION
To allow the user of our driver to inject credentials from different sources we now support to load the credentials from an extra file. If the driver_config_credentials_path is defined, the driver will load it and patch credentials used inside the driver config where appropriate.

This was implemented to load credentials from a Kubernetes secret, while keeping the rest of the config inside a config map.