### PR TITLE
Nxos agent config preparations

### DIFF
--- a/networking_ccloud/common/config/config_driver.py
+++ b/networking_ccloud/common/config/config_driver.py
@@ -206,7 +206,7 @@ class SwitchPort(pydantic.BaseModel):
     @pydantic.root_validator
     def set_portchannel_id_for_lacp(cls, values):
         if values['lacp'] and not values['portchannel_id']:
-            m = re.match(r"^port-channel\s*(?P<pc_id>\d+)$", values['name'].lower())
+            m = re.match(r"^(?:port-channel|po)\s*(?P<pc_id>\d+)$", values['name'].lower())
             if not m:
                 raise ValueError(f"No pc id given for {values['switch']}/{values['name']} and could not parse one "
                                  f"from interface name")

--- a/networking_ccloud/common/config/config_driver.py
+++ b/networking_ccloud/common/config/config_driver.py
@@ -140,17 +140,9 @@ class SwitchGroup(pydantic.BaseModel):
 
     @pydantic.validator('members')
     def validate_members(cls, v):
-        # we currently plan with having exactly two members in each group
-        if len(v) != 2:
-            raise ValueError(f"Expected two switch members, got {len(v)} - "
-                             "the code should work with other member counts, but this "
-                             "should be checked beforehand")
-
-        # members need to be of the same platform
-        platforms = set(s.platform for s in v)
-        if len(platforms) > 1:
-            raise ValueError("Switchgroup members need to have the same platform! Found {}"
-                             .format(", ".join(f"{s.name} of type {s.platform}" for s in v)))
+        # we currently plan having two or more members in each group
+        if len(v) < 2:
+            raise ValueError(f"Expected two or more switch members, got {len(v)}")
 
         return v
 

--- a/networking_ccloud/ml2/agent/common/messages.py
+++ b/networking_ccloud/ml2/agent/common/messages.py
@@ -99,6 +99,7 @@ class Vlan(pydantic.BaseModel):
 class VXLANMapping(pydantic.BaseModel):
     vni: pydantic.conint(gt=0, lt=2**24)
     vlan: pydantic.conint(gt=0, lt=4094)
+    enable_multisite: bool = False
 
     def __lt__(self, other):
         return self.vlan < other.vlan
@@ -196,6 +197,7 @@ class BGP(pydantic.BaseModel):
         rt = f"{az_num}:{vni}"
         bvargs = dict(rt_imports=[rt], rt_exports=[rt])
         if bgw_mode:
+            # eos-specific bgw config
             bgw_rt = f"{self.asn_region}:{vni}"
             bvargs['rd_evpn_domain_all'] = True
             bvargs['rt_imports_evpn'] = [bgw_rt]
@@ -315,13 +317,13 @@ class SwitchConfigUpdate(pydantic.BaseModel):
                 return
         self.vlans.append(Vlan(vlan=vlan, name=name))
 
-    def add_vxlan_map(self, vni, vlan):
+    def add_vxlan_map(self, vni, vlan, bgw_mode=False):
         if self.vxlan_maps is None:
             self.vxlan_maps = []
         for vm in self.vxlan_maps:
             if vm.vni == vni and vm.vlan == vlan:
                 return
-        self.vxlan_maps.append(VXLANMapping(vni=vni, vlan=vlan))
+        self.vxlan_maps.append(VXLANMapping(vni=vni, vlan=vlan, enable_multisite=bgw_mode))
 
     def add_iface(self, iface):
         if self.ifaces is None:
@@ -408,7 +410,7 @@ class SwitchConfigUpdateList:
             # vlan-vxlan mapping
             if seg_vni and (add or not keep_mapping):
                 scu.add_vlan(seg_vlan, network_id)
-                scu.add_vxlan_map(seg_vni, seg_vlan)
+                scu.add_vxlan_map(seg_vni, seg_vlan, bgw_mode=is_bgw)
 
             # gateways
             if gateways:

--- a/networking_ccloud/tests/unit/common/test_driver_config.py
+++ b/networking_ccloud/tests/unit/common/test_driver_config.py
@@ -30,16 +30,6 @@ class TestDriverConfigValidation(base.TestCase):
         return config.Switch(name=name, host=host, platform=platform, user="admin", password="maunz",
                              bgp_source_ip="2.3.4.5")
 
-    def test_switchgroup_two_members(self):
-        sw1 = self.make_switch("sw1")
-        sw2 = self.make_switch("sw2")
-        sw3 = self.make_switch("sw3")
-        sg_args = dict(name="foo", availability_zone="qa-de-1a", role="vpod", vtep_ip="1.1.1.1", asn=65001, group_id=1)
-
-        self.assertRaises(ValueError, config.SwitchGroup, members=[sw1], **sg_args)
-        self.assertRaises(ValueError, config.SwitchGroup, members=[sw1, sw2, sw3], **sg_args)
-        config.SwitchGroup(members=[sw1, sw2], **sg_args)
-
     def test_switchgroup_group_ids_uniq(self):
         gc = cfix.make_global_config()
         sg1 = cfix.make_switchgroup("seagull", group_id=1000)

--- a/networking_ccloud/tests/unit/common/test_driver_config.py
+++ b/networking_ccloud/tests/unit/common/test_driver_config.py
@@ -61,7 +61,8 @@ class TestDriverConfigValidation(base.TestCase):
                                config.SwitchPort, lacp=False, portchannel_id=23, **defargs)
 
     def test_switchport_pc_id_parsing(self):
-        cases = [("Port-Channel23", 23), ("port-channel42", 42), ("port-Channel 1337", 1337)]
+        cases = [
+            ("Port-Channel23", 23), ("port-channel42", 42), ("port-Channel 1337", 1337), ("po23", 23)]
         for pc_name, pc_id in cases:
             sp = config.SwitchPort(switch='sw-seagull', name=pc_name, lacp=True, members=["krakrakra"])
             self.assertEqual(pc_id, sp.portchannel_id, f"Could not parse pc id from {pc_name}")

--- a/networking_ccloud/tests/unit/extensions/test_extensions.py
+++ b/networking_ccloud/tests/unit/extensions/test_extensions.py
@@ -382,7 +382,7 @@ class TestNetworkExtension(test_segment.SegmentTestCase, base.PortBindingHelper,
             swcfgs = mock_acu.call_args[0][1]
             self.assertEqual({"transit1-sw1"}, set(s.switch_name for s in swcfgs))
             for swcfg in swcfgs:
-                self.assertEqual([{'vni': 232323, 'vlan': 111}], swcfg.vxlan_maps)
+                self.assertEqual([{'vni': 232323, 'vlan': 111, 'enable_multisite': False}], swcfg.vxlan_maps)
                 self.assertIsNone(swcfg.ifaces)
 
     def test_switch_get_config(self):

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ deps = -c{toxinidir}/lower-constraints.txt
 
 [testenv:pep8]
 commands =
+    pip install -U flake8
     flake8 {posargs}
     neutron-db-manage --subproject=networking-ccloud check_migration
 


### PR DESCRIPTION
This is everything we need to get the NXOS config rolling for the fabric driver (at least everything I know of) and also supports mixed-vendor switchgroups, so we can act as if multiple EVPN domains are one in our qa landscape. I also included the multisite part, so we'll only need to patch the agent in most cases when we're continuing development on the NXOS agent.