### PR TITLE
EOS GNMI compatibility for EOS >= 4.32

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
 sphinx>=2.0.0,!=2.1.0 # BSD
-openstackdocstheme>=2.2.1 # Apache-2.0
+openstackdocstheme>=2.2.1,<3.4 # Apache-2.0
 # releasenotes
 reno>=3.1.0 # Apache-2.0

--- a/networking_ccloud/ml2/agent/eos/switch.py
+++ b/networking_ccloud/ml2/agent/eos/switch.py
@@ -40,8 +40,13 @@ class EOSGNMIPaths:
     VLAN = "network-instances/network-instance[name=default]/vlans/vlan[vlan-id={vlan}]"
 
     VXMAPS = "interfaces/interface[name=Vxlan1]/arista-exp-eos-vxlan:arista-vxlan/config/vlan-to-vnis"
+    VXMAPS_ALL_4_32 = ("interfaces/interface[name=Vxlan1]/arista-exp-eos-vxlan:arista-vxlan/vlan-to-vnis/"
+                       "vlan-to-vni/config")
+    VXMAPS_CONFIG_4_32 = "interfaces/interface[name=Vxlan1]/arista-exp-eos-vxlan:arista-vxlan/vlan-to-vnis"
     VXMAP_VLAN = ("interfaces/interface[name=Vxlan1]/arista-exp-eos-vxlan:arista-vxlan/config/vlan-to-vnis"
                   "/vlan-to-vni[vlan={vlan}]")
+    VXMAP_VLAN_4_32 = ("interfaces/interface[name=Vxlan1]/arista-exp-eos-vxlan:arista-vxlan/vlan-to-vnis"
+                       "/vlan-to-vni[vlan={vlan}]")
     VRF_VXMAPS = "interfaces/interface[name=Vxlan1]/arista-exp-eos-vxlan:arista-vxlan/config/vrf-to-vnis"
     VRF_VXMAP_VRF = ("interfaces/interface[name=Vxlan1]/arista-exp-eos-vxlan:arista-vxlan/config/vrf-to-vnis/"
                      "vrf-to-vni[vrf={vrf}]")
@@ -49,13 +54,14 @@ class EOSGNMIPaths:
     EVPN_INSTANCES = "arista/eos/arista-exp-eos-evpn:evpn/evpn-instances"
     EVPN_INSTANCE = "arista/eos/arista-exp-eos-evpn:evpn/evpn-instances/evpn-instance[name={vlan}]"
     EVPN_INSTANCES_VIA_SYSDB = "eos_native:Sysdb/routing/bgp/macvrf/config"
-    PROTO_BGP = "network-instances/network-instance[name=default]/protocols/protocol[name=BGP]"
+    PROTO_BGP = "network-instances/network-instance[name=default]/protocols/protocol[name=BGP][identifier=BGP]"
     NETWORK_INSTANCES = "network-instances"
     NETWORK_INSTANCE_IFACES = "network-instances/network-instance[name={vrf}]/interfaces"
-    BGP_VRF_AGGREGATES = ("network-instances/network-instance[name={vrf}]/protocols/protocol[name=BGP]/"
+    BGP_VRF_AGGREGATES = ("network-instances/network-instance[name={vrf}]/protocols/protocol[name=BGP][identifier=BGP]/"
                           "bgp/global/afi-safis/afi-safi[afi-safi-name=openconfig-bgp-types:IPV4_UNICAST]/"
                           "aggregate-addresses")
-    BGP_VRF_AGGREGATE_PREFIX = ("network-instances/network-instance[name={vrf}]/protocols/protocol[name=BGP]/"
+    BGP_VRF_AGGREGATE_PREFIX = ("network-instances/network-instance[name={vrf}]/protocols/"
+                                "protocol[name=BGP][identifier=BGP]/"
                                 "bgp/global/afi-safis/afi-safi[afi-safi-name=openconfig-bgp-types:IPV4_UNICAST]/"
                                 "aggregate-addresses/aggregate-address[aggregate-address={prefix}]")
     PREFIX_LISTS = "routing-policy/defined-sets/prefix-sets"
@@ -105,11 +111,30 @@ class EOSSwitch(SwitchBase):
     # PL-CC-CLOUD02 | PL-CC-CLOUD02-A | PL-CC-CLOUD02-EXTERNAL | PL-CC-CLOUD02-A-EXTERNAL
     PREFIX_LIST_RE = re.compile("PL-(?P<vrf>.*?)(?:-(?P<az>[A-Z]))?(?:-(?P<external>EXTERNAL))?$")
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._reset_version_detection()
+
+    def _reset_version_detection(self):
+        self._version_min_4_32 = None
+
+    @property
+    def version_min_4_32(self):
+        if self._version_min_4_32 is None:
+            ver_data = self.api.get(path=["cli:/show version"])
+            ver = ver_data['version'].split(".")
+            ver_tuple = (int(ver[0]), int(ver[1]))
+            self._version_min_4_32 = ver_tuple >= (4, 32)
+        return self._version_min_4_32
+
     @classmethod
     def get_platform(cls):
         return cc_const.PLATFORM_EOS
 
     def login(self):
+        self._reset_version_detection()
+
         self._api = CCGNMIClient(switch_name=self.name, host=self.host, port=6030,
                                  username=self.user, password=self._password, platform=self.get_platform(),
                                  insecure=False, skip_verify=True)
@@ -208,9 +233,15 @@ class EOSSwitch(SwitchBase):
                 config_req.delete.append(vpath)
 
     def get_vxlan_mappings(self, with_unmanaged=False) -> List[agent_msg.VXLANMapping]:
-        swdata = self.api.get(EOSGNMIPaths.VXMAPS)['arista-exp-eos-vxlan:vlan-to-vni']
-        vxlan_maps = [agent_msg.VXLANMapping(vni=v['vni'], vlan=v['vlan']) for v in swdata
-                      if with_unmanaged or v['vlan'] in self.managed_vlans]
+        if self.version_min_4_32:
+            swdata = self.api.get(EOSGNMIPaths.VXMAPS_ALL_4_32, single=False)
+            vxlan_maps = [agent_msg.VXLANMapping(vni=v['arista-exp-eos-vxlan:vni'], vlan=v['arista-exp-eos-vxlan:vlan'])
+                          for v in swdata
+                          if with_unmanaged or v['arista-exp-eos-vxlan:vlan'] in self.managed_vlans]
+        else:
+            swdata = self.api.get(EOSGNMIPaths.VXMAPS)['arista-exp-eos-vxlan:vlan-to-vni']
+            vxlan_maps = [agent_msg.VXLANMapping(vni=v['vni'], vlan=v['vlan']) for v in swdata
+                          if with_unmanaged or v['vlan'] in self.managed_vlans]
         vxlan_maps.sort()
         return vxlan_maps
 
@@ -218,6 +249,8 @@ class EOSSwitch(SwitchBase):
                                    operation: Op) -> None:
         if vxlan_maps is None:
             return
+
+        VXMAP_VLAN_PATH = EOSGNMIPaths.VXMAP_VLAN_4_32 if self.version_min_4_32 else EOSGNMIPaths.VXMAP_VLAN
 
         curr_maps = self.get_vxlan_mappings(with_unmanaged=True)
         if operation in (Op.add, Op.replace):
@@ -229,7 +262,7 @@ class EOSSwitch(SwitchBase):
                 for vlan in vmaps_to_remove:
                     LOG.debug("Removing stale vlan mapping for vlan %s from %s (%s) on config replace",
                               vlan, self.name, self.host)
-                    config_req.delete.append(EOSGNMIPaths.VXMAP_VLAN.format(vlan=vlan))
+                    config_req.delete.append(VXMAP_VLAN_PATH.format(vlan=vlan))
 
             # delete all mappings for VNIs we want to repurpose, but are used by a different vlan
             for curr_map in curr_maps:
@@ -238,18 +271,22 @@ class EOSSwitch(SwitchBase):
                         LOG.warning("Removing stale vxlan map <vlan %s vni %s> in favor of <vlan %s vni %s> "
                                     "on switch %s (%s)",
                                     curr_map.vlan, curr_map.vni, os_map.vlan, os_map.vni, self.name, self.host)
-                        del_map = EOSGNMIPaths.VXMAP_VLAN.format(vlan=curr_map.vlan)
+                        del_map = VXMAP_VLAN_PATH.format(vlan=curr_map.vlan)
                         config_req.delete.append(del_map)
 
-            mapcfgs = [{'vlan': vmap.vlan, 'vni': vmap.vni} for vmap in vxlan_maps]
-            config_req.update.append((EOSGNMIPaths.VXMAPS, {'vlan-to-vni': mapcfgs}))
+            if self.version_min_4_32:
+                mapcfgs = [{'vlan': vmap.vlan, 'config': {'vlan': vmap.vlan, 'vni': vmap.vni}} for vmap in vxlan_maps]
+                config_req.update.append((EOSGNMIPaths.VXMAPS_CONFIG_4_32, {'vlan-to-vni': mapcfgs}))
+            else:
+                mapcfgs = [{'vlan': vmap.vlan, 'vni': vmap.vni} for vmap in vxlan_maps]
+                config_req.update.append((EOSGNMIPaths.VXMAPS, {'vlan-to-vni': mapcfgs}))
         else:
             # delete vlan mapping only if it has the right vni
             for os_map in vxlan_maps:
                 for curr_map in curr_maps:
                     if curr_map.vlan == os_map.vlan:
                         if curr_map.vni == os_map.vni:
-                            config_req.delete.append(EOSGNMIPaths.VXMAP_VLAN.format(vlan=curr_map.vlan))
+                            config_req.delete.append(VXMAP_VLAN_PATH.format(vlan=curr_map.vlan))
                         else:
                             LOG.warning("Not deleting vlan %s from switch %s (%s), as it points to vni %s "
                                         "(delete requested vni %s)",

--- a/networking_ccloud/tests/unit/ml2/agent/eos/test_switch.py
+++ b/networking_ccloud/tests/unit/ml2/agent/eos/test_switch.py
@@ -54,8 +54,14 @@ class TestEOSConfigUpdates(base.TestCase):
         self.switch._api.set.assert_called_with(update=expected_update, delete=[], replace=[])
 
     def test_add_everything(self):
-        def _get(prefix, unpack=True):
-            if prefix == 'interfaces/interface[name=Vxlan1]/arista-exp-eos-vxlan:arista-vxlan/config/vlan-to-vnis':
+        def _get(prefix=None, path=None, unpack=True):
+            if prefix and path:
+                raise ValueError("Cannot set prefix and path at the same time")
+            elif path and path[0] == "cli:/show version":
+                return {
+                    "version": "4.28.3M"
+                }
+            elif prefix == 'interfaces/interface[name=Vxlan1]/arista-exp-eos-vxlan:arista-vxlan/config/vlan-to-vnis':
                 return {'arista-exp-eos-vxlan:vlan-to-vni': [{'vlan': 1337, 'vni': 232323}]}
             elif prefix == 'interfaces':
                 return {
@@ -87,8 +93,8 @@ class TestEOSConfigUpdates(base.TestCase):
                                           'import': ['1:232323']}},
               'vlans': {'vlan': [{'config': {'vlan-id': 1000},
                                   'vlan-id': 1000}]}}),
-            ('network-instances/network-instance[name=CC-SEAGULL]/protocols/protocol[name=BGP]/bgp/global/'
-             'afi-safis/afi-safi[afi-safi-name=openconfig-bgp-types:IPV4_UNICAST]/aggregate-addresses', {
+            ('network-instances/network-instance[name=CC-SEAGULL]/protocols/protocol[name=BGP][identifier=BGP]/'
+             'bgp/global/afi-safis/afi-safi[afi-safi-name=openconfig-bgp-types:IPV4_UNICAST]/aggregate-addresses', {
                  'aggregate-address': [
                      {'aggregate-address': '8.8.8.0/24',
                       'config': {'aggregate-address': '8.8.8.0/24', 'attribute-map': 'RM-CC-SEAGULL-AGGREGATE'}},
@@ -318,8 +324,14 @@ class TestEOSConfigUpdates(base.TestCase):
                                                 delete=expected_delete_config)
 
     def test_remove_everything(self):
-        def _get(prefix, unpack=True):
-            if prefix == 'interfaces/interface[name=Vxlan1]/arista-exp-eos-vxlan:arista-vxlan/config/vlan-to-vnis':
+        def _get(prefix=None, path=None, unpack=True):
+            if prefix and path:
+                raise ValueError("Cannot set prefix and path at same time")
+            elif path and path[0] == "cli:/show version":
+                return {
+                    "version": "4.28.3M"
+                }
+            elif prefix == 'interfaces/interface[name=Vxlan1]/arista-exp-eos-vxlan:arista-vxlan/config/vlan-to-vnis':
                 return {'arista-exp-eos-vxlan:vlan-to-vni': [
                         {'vlan': 1000, 'vni': 171717},
                         {'vlan': 2000, 'vni': 232323},
@@ -376,11 +388,11 @@ class TestEOSConfigUpdates(base.TestCase):
                 'prefixes/prefix[ip-prefix=7.7.7.0/24]',
                 'routing-policy/defined-sets/prefix-sets/prefix-set[name=PL-CC-SEAGULL-A-EXTERNAL]/'
                 'prefixes/prefix[ip-prefix=10.10.10.0/24]',
-                'network-instances/network-instance[name=CC-SEAGULL]/protocols/protocol[name=BGP]/bgp/global/'
-                'afi-safis/afi-safi[afi-safi-name=openconfig-bgp-types:IPV4_UNICAST]/'
+                'network-instances/network-instance[name=CC-SEAGULL]/protocols/protocol[name=BGP][identifier=BGP]/'
+                'bgp/global/afi-safis/afi-safi[afi-safi-name=openconfig-bgp-types:IPV4_UNICAST]/'
                 'aggregate-addresses/aggregate-address[aggregate-address=8.8.8.0/24]',
-                'network-instances/network-instance[name=CC-SEAGULL]/protocols/protocol[name=BGP]/bgp/global/'
-                'afi-safis/afi-safi[afi-safi-name=openconfig-bgp-types:IPV4_UNICAST]/'
+                'network-instances/network-instance[name=CC-SEAGULL]/protocols/protocol[name=BGP][identifier=BGP]/'
+                'bgp/global/afi-safis/afi-safi[afi-safi-name=openconfig-bgp-types:IPV4_UNICAST]/'
                 'aggregate-addresses/aggregate-address[aggregate-address=9.9.9.0/24]',
                 'interfaces/interface[name=Port-Channel23]/aggregation/switched-vlan/config/native-vlan',
                 'interfaces/interface[name=Port-Channel23]/aggregation/switched-vlan/vlan-translation/'
@@ -466,8 +478,14 @@ class TestEOSConfigUpdates(base.TestCase):
         self.switch._api.set.assert_called_with(**expected_config)
 
     def test_add_vlan_map_with_existing(self):
-        def _get(prefix):
-            if prefix == 'interfaces/interface[name=Vxlan1]/arista-exp-eos-vxlan:arista-vxlan/config/vlan-to-vnis':
+        def _get(prefix=None, path=None):
+            if prefix and path:
+                raise ValueError("Cannot set prefix and path at same time")
+            elif path and path[0] == "cli:/show version":
+                return {
+                    "version": "4.28.3M"
+                }
+            elif prefix == 'interfaces/interface[name=Vxlan1]/arista-exp-eos-vxlan:arista-vxlan/config/vlan-to-vnis':
                 return {'arista-exp-eos-vxlan:vlan-to-vni': [
                         {'vlan': 2000, 'vni': 31337},
                         {'vlan': 2500, 'vni': 232323},
@@ -534,8 +552,14 @@ class TestEOSConfigUpdates(base.TestCase):
         self.switch._api.set.assert_called_with(**expected_config)
 
     def test_update_vxlan_maps(self):
-        def _get(prefix):
-            if prefix == 'interfaces/interface[name=Vxlan1]/arista-exp-eos-vxlan:arista-vxlan/config/vlan-to-vnis':
+        def _get(prefix=None, path=None):
+            if prefix and path:
+                raise ValueError("Cannot set prefix and path at same time")
+            elif path and path[0] == "cli:/show version":
+                return {
+                    "version": "4.28.3M"
+                }
+            elif prefix == 'interfaces/interface[name=Vxlan1]/arista-exp-eos-vxlan:arista-vxlan/config/vlan-to-vnis':
                 return {'arista-exp-eos-vxlan:vlan-to-vni': [
                         {'vlan': 42, 'vni': 23},
                         {'vlan': 444, 'vni': 2000},
@@ -560,9 +584,52 @@ class TestEOSConfigUpdates(base.TestCase):
         self.switch.apply_config_update(cu).result()
         self.switch._api.set.assert_called_with(**expected_config)
 
+    def test_update_vxlan_maps_eos_4_32(self):
+        def _get(prefix=None, path=None, single=True):
+            if prefix and path:
+                raise ValueError("Cannot set prefix and path at same time")
+            elif path and path[0] == "cli:/show version":
+                return {
+                    "version": "4.32.3M"
+                }
+            elif prefix == ('interfaces/interface[name=Vxlan1]/arista-exp-eos-vxlan:arista-vxlan/'
+                            'vlan-to-vnis/vlan-to-vni/config') \
+                    and not single:
+                return [
+                    {'arista-exp-eos-vxlan:vlan': 42, 'arista-exp-eos-vxlan:vni': 23},
+                    {'arista-exp-eos-vxlan:vlan': 444, 'arista-exp-eos-vxlan:vni': 2000},
+                    {'arista-exp-eos-vxlan:vlan': 2000, 'arista-exp-eos-vxlan:vni': 232323},
+                ]
+        self.switch._api.get.side_effect = _get
+
+        expected_config = {
+            'delete': [
+                'interfaces/interface[name=Vxlan1]/arista-exp-eos-vxlan:arista-vxlan/vlan-to-vnis/'
+                'vlan-to-vni[vlan=2000]'
+            ],
+            'update': [('interfaces/interface[name=Vxlan1]/arista-exp-eos-vxlan:arista-vxlan/vlan-to-vnis',
+                        {'vlan-to-vni': [{'vlan': 42, 'config': {'vlan': 42, 'vni': 23}},
+                                         {'vlan': 1337, 'config': {'vlan': 1337, 'vni': 232323}}]})],
+            'replace': [],
+        }
+
+        cu = messages.SwitchConfigUpdate(switch_name="seagull-sw1", operation=messages.OperationEnum.add)
+        # vlans
+        cu.add_vxlan_map(23, 42)
+        cu.add_vxlan_map(232323, 1337)
+
+        self.switch.apply_config_update(cu).result()
+        self.switch._api.set.assert_called_with(**expected_config)
+
     def test_replace_vxlan_maps(self):
-        def _get(prefix):
-            if prefix == 'interfaces/interface[name=Vxlan1]/arista-exp-eos-vxlan:arista-vxlan/config/vlan-to-vnis':
+        def _get(prefix=None, path=None):
+            if prefix and path:
+                raise ValueError("Cannot set prefix and path at same time")
+            elif path and path[0] == "cli:/show version":
+                return {
+                    "version": "4.28.3M"
+                }
+            elif prefix == 'interfaces/interface[name=Vxlan1]/arista-exp-eos-vxlan:arista-vxlan/config/vlan-to-vnis':
                 return {'arista-exp-eos-vxlan:vlan-to-vni': [
                         {'vlan': 42, 'vni': 23},
                         {'vlan': 444, 'vni': 200444},
@@ -636,11 +703,11 @@ class TestEOSConfigUpdates(base.TestCase):
 
         expected_config = {
             'delete': [
-                'network-instances/network-instance[name=CC-SEAGULL]/protocols/protocol[name=BGP]/bgp/global/'
-                'afi-safis/afi-safi[afi-safi-name=openconfig-bgp-types:IPV4_UNICAST]/'
+                'network-instances/network-instance[name=CC-SEAGULL]/protocols/protocol[name=BGP][identifier=BGP]/'
+                'bgp/global/afi-safis/afi-safi[afi-safi-name=openconfig-bgp-types:IPV4_UNICAST]/'
                 'aggregate-addresses/aggregate-address[aggregate-address=1.1.1.0/24]',
-                'network-instances/network-instance[name=CC-SEAGULL]/protocols/protocol[name=BGP]/bgp/global/'
-                'afi-safis/afi-safi[afi-safi-name=openconfig-bgp-types:IPV4_UNICAST]/'
+                'network-instances/network-instance[name=CC-SEAGULL]/protocols/protocol[name=BGP][identifier=BGP]/'
+                'bgp/global/afi-safis/afi-safi[afi-safi-name=openconfig-bgp-types:IPV4_UNICAST]/'
                 'aggregate-addresses/aggregate-address[aggregate-address=2.2.2.0/24]',
             ],
             'replace': [
@@ -658,8 +725,8 @@ class TestEOSConfigUpdates(base.TestCase):
                   'prefixes': {'prefix': []}}),
             ],
             'update': [
-                ('network-instances/network-instance[name=CC-SEAGULL]/protocols/protocol[name=BGP]/bgp/global/'
-                 'afi-safis/afi-safi[afi-safi-name=openconfig-bgp-types:IPV4_UNICAST]/aggregate-addresses',
+                ('network-instances/network-instance[name=CC-SEAGULL]/protocols/protocol[name=BGP][identifier=BGP]'
+                 '/bgp/global/afi-safis/afi-safi[afi-safi-name=openconfig-bgp-types:IPV4_UNICAST]/aggregate-addresses',
                     {'aggregate-address': [
                         {'aggregate-address': '8.8.8.0/24',
                          'config': {'aggregate-address': '8.8.8.0/24', 'attribute-map': 'RM-CC-SEAGULL-AGGREGATE'}},
@@ -994,8 +1061,14 @@ class TestEOSSwitch(base.TestCase):
         self.switch._api.execute.return_value = {'result': [{}]}
 
     def test_get_switch_config(self):
-        def _get(prefix, unpack=True):
-            if prefix == 'network-instances/network-instance[name=default]/vlans':
+        def _get(prefix=None, path=None, unpack=True):
+            if prefix and path:
+                raise ValueError("Cannot set prefix and path the at same time")
+            elif path and path[0] == "cli:/show version":
+                return {
+                    "version": "4.28.3M"
+                }
+            elif prefix == 'network-instances/network-instance[name=default]/vlans':
                 return {
                     'openconfig-network-instance:vlan': [
                         {'config': {'vlan-id': 2121, 'name': 'b226a569-e0ed-4d24-b943-c7183288'},
@@ -1005,7 +1078,8 @@ class TestEOSSwitch(base.TestCase):
                     ]}
             elif prefix == 'interfaces/interface[name=Vxlan1]/arista-exp-eos-vxlan:arista-vxlan/config/vlan-to-vnis':
                 return {'arista-exp-eos-vxlan:vlan-to-vni': [{'vlan': 2121, 'vni': 31337}]}
-            elif prefix == ('network-instances/network-instance[name=default]/protocols/protocol[name=BGP]/'
+            elif prefix == ('network-instances/network-instance[name=default]/'
+                            'protocols/protocol[name=BGP][identifier=BGP]/'
                             'bgp/global/config/as'):
                 return 4268363793
             elif prefix == 'arista/eos/arista-exp-eos-evpn:evpn/evpn-instances':


### PR DESCRIPTION
Somewhere between EOS 4.28.9M and 4.32.3M the GNMI structure for vlan-vni mappings and for aggregates changed.

For vlan-vni mappings the path changed, so we now need to check on which version we are and use the corresponding path for querying and configuring them. It's a bit weird now as each vlan element has a config and a state entry, but it looks like EOS just wants to introduce more state reporting into their GNMI API.

For the aggregates, we now need to filter both for protocol name and identifier name. In case of BGP they're both BGP. Querying works even without specifying the identifier, but configuration does not work anymore. Adding [identifier=BGP] to all of them solves this problem.

With these two changes we now need to implement a version switch. For now the version is fetched on first use and gets reset on each connect, so we make sure that we pick up new versions if we loose the GNMI connection (as this could very well be caused by a switch firmware update!). The version check is a rather simple tuple conversion / comparison and is currently based on the assumption that the first two parts of the version number will always be plain numeric (like 4.32.3M).