### PR TITLE
agents: register common config options

### DIFF
--- a/networking_ccloud/ml2/agent/common/agent.py
+++ b/networking_ccloud/ml2/agent/common/agent.py
@@ -140,6 +140,7 @@ class CCFabricSwitchAgent(manager.Manager, cc_agent_api.CCFabricSwitchAgentAPI):
 
     @classmethod
     def run_agent_main(cls):
+        common_config.register_common_config_options()
         register_agent_state_opts_helper(cfg.CONF)
         common_config.init(sys.argv[1:])
         common_config.setup_logging()


### PR DESCRIPTION
With OpenStack Caracal / 2024.1 we need to register common config options for them to be usable. Without this, the base agent code of Neutron will not work properly.