### PR TITLE
Fall back to region ASN for stretched RT

### DIFF
--- a/networking_ccloud/common/config/config_oslo.py
+++ b/networking_ccloud/common/config/config_oslo.py
@@ -34,7 +34,8 @@ cc_fabric_opts = [
     cfg.IntOpt("aci_bgw_rt_admin_value", default=23456,
                help="Admin field value used by ACI on BGWs for the first part of the RT"),
     cfg.IntOpt("stretch_route_target_admin_value", default=0,
-               help="Default stretch rt admin value for route targets, will be used as $val:$vni"),
+               help="Default stretch rt admin value for route targets, will be used as $val:$vni. If not specified "
+                    "or set to 0, fall back to the region ASN."),
 ]
 
 cc_fabric_agent_opts = [

--- a/networking_ccloud/ml2/agent/common/messages.py
+++ b/networking_ccloud/ml2/agent/common/messages.py
@@ -410,6 +410,8 @@ class SwitchConfigUpdateList:
                 sg = self.drv_conf.get_switchgroup_by_switch_name(switch.name)
                 if is_stretched:
                     switch_az_num = cfg.CONF.ml2_cc_fabric.stretch_route_target_admin_value
+                    if not switch_az_num:
+                        switch_az_num = self.drv_conf.global_config.asn_region
                 else:
                     switch_az_num = self.drv_conf.global_config.get_availability_zone(sg.availability_zone).number
                 if not scu.bgp:


### PR DESCRIPTION
On NXOS 0 is an invalid admin RT value. We might want to go with an explicit value here in the future (like 10), but for now we just fall back to the global ASN from the driver config.