### PR TITLE
Improve IPv6 compatibility

### DIFF
--- a/networking_ccloud/common/helper.py
+++ b/networking_ccloud/common/helper.py
@@ -12,6 +12,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import ipaddress
 import json
 
 from neutron_lib.api.definitions import portbindings as pb_api
@@ -86,3 +87,19 @@ def merge_segment_dicts(segments_a, segments_b):
 
     # we only return this for convenience, update is done in-place
     return segments_a
+
+
+def get_ip_version(ip_or_net):
+    return ipaddress.ip_interface(ip_or_net).version
+
+
+def split_by_address_family(ip_list):
+    v4 = []
+    v6 = []
+    for ip in ip_list:
+        if get_ip_version(ip) == 4:
+            v4.append(ip)
+        else:
+            v6.append(ip)
+
+    return v4, v6

--- a/networking_ccloud/ml2/agent/common/messages.py
+++ b/networking_ccloud/ml2/agent/common/messages.py
@@ -22,6 +22,7 @@ from oslo_log import log as logging
 import pydantic
 
 from networking_ccloud.common.config.config_driver import validate_asn
+from networking_ccloud.common.helper import split_by_address_family
 from networking_ccloud.ml2.agent.common.api import CCFabricSwitchAgentRPCClient
 
 LOG = logging.getLogger(__name__)
@@ -278,8 +279,28 @@ class VlanIface(pydantic.BaseModel):
     vlan: pydantic.conint(gt=0, lt=4094)
     vrf: str = None
 
-    primary_ip: str = None
-    secondary_ips: List[str] = None
+    primary_ip_v4: str | None = None
+    primary_ip_v6: str | None = None
+    secondary_ips_v4: List[str] | None = None
+    secondary_ips_v6: List[str] | None = None
+
+    @pydantic.validator("primary_ip_v4", "secondary_ips_v4", each_item=True, pre=True, allow_reuse=True)
+    def validate_ipv4(cls, v):
+        if v is not None:
+            try:
+                ipaddress.IPv4Interface(v)
+            except ValueError:
+                raise ValueError(f"{v} is not a valid IPv4 address/prefix")
+        return v
+
+    @pydantic.validator("primary_ip_v6", "secondary_ips_v6", each_item=True, pre=True, allow_reuse=True)
+    def validate_ipv6(cls, v):
+        if v is not None:
+            try:
+                ipaddress.IPv6Interface(v)
+            except ValueError:
+                raise ValueError(f"{v} is not a valid IPv6 address/prefix")
+        return v
 
     def __lt__(self, other):
         return self.vlan < other.vlan
@@ -397,7 +418,7 @@ class SwitchConfigUpdateList:
          * keep_mapping: determines if the vlan-vni mapping is kept on op=remove/replace
          * exclude_hosts: hosts to exclude if a metagroup is being bound
          * is_bgw: bordergateway mode - no ifaces will be configured, bgp stanzas marked as bgw
-         * gateways: all gateways configured for this binding host ({'vrf': name, 'ips': [gw, gw, gw]})
+         * gateways: all gateways configured for this binding host ({'vrf': name, 'ips_v4': [gw, gw], 'ips_v6': ...})
          * is_stretched: mark network as stretched / az aware in BGP
         """
         add = self.operation == OperationEnum.add
@@ -426,8 +447,15 @@ class SwitchConfigUpdateList:
 
             # gateways
             if gateways and not is_bgw:
-                scu.add_vlan_iface(vlan=seg_vlan, vrf=gateways['vrf'], primary_ip=gateways['ips'][0],
-                                   secondary_ips=gateways['ips'][1:])
+                # make sure gateways are sorted so we have a stable list
+                gws_v4 = gateways['ips_v4']
+                gws_v4.sort(key=ipaddress.ip_interface)
+                gws_v6 = gateways['ips_v6']
+                gws_v6.sort(key=ipaddress.ip_interface)
+
+                scu.add_vlan_iface(vlan=seg_vlan, vrf=gateways['vrf'],
+                                   primary_ip_v4=next(iter(gws_v4), None), secondary_ips_v4=gws_v4[1:],
+                                   primary_ip_v6=next(iter(gws_v6), None), secondary_ips_v6=gws_v6[1:])
 
             # interface config
             if not is_bgw:
@@ -470,7 +498,8 @@ class SwitchConfigUpdateList:
             # FIXME: exclude hosts
             gateways = None
             if inet.vrf:
-                gateways = {'vrf': inet.vrf, 'ips': inet.networks}
+                gws_v4, gws_v6 = split_by_address_family(inet.networks)
+                gateways = {'vrf': inet.vrf, 'ips_v4': gws_v4, 'ips_v6': gws_v6}
 
             self.add_binding_host_to_config(hg_config, inet.name, inet.vni, inet.vlan,
                                             gateways=gateways, override_native=inet.untagged and process_untagged)

--- a/networking_ccloud/ml2/agent/eos/switch.py
+++ b/networking_ccloud/ml2/agent/eos/switch.py
@@ -20,6 +20,7 @@ import uuid
 from oslo_log import log as logging
 
 from networking_ccloud.common import constants as cc_const
+from networking_ccloud.common.helper import get_ip_version
 from networking_ccloud.ml2.agent.common.gnmi import CCGNMIClient
 from networking_ccloud.ml2.agent.common import messages as agent_msg
 from networking_ccloud.ml2.agent.common.messages import OperationEnum as Op
@@ -504,7 +505,9 @@ class EOSSwitch(SwitchBase):
                 aggregates = [{'aggregate-address': agg.network,
                                'config': {'aggregate-address': agg.network,
                                           'attribute-map': self.gen_route_map_name(bgp_vrf.name, agg.az_local)}}
-                              for agg in bgp_vrf.aggregates or []]
+                              for agg in bgp_vrf.aggregates or []
+                              # TODO(seba): implement ipv6
+                              if get_ip_version(agg.network) == 4]
                 config_req.update.append((EOSGNMIPaths.BGP_VRF_AGGREGATES.format(vrf=bgp_vrf.name),
                                           {'aggregate-address': aggregates}))
 
@@ -514,6 +517,9 @@ class EOSSwitch(SwitchBase):
                                 for az_local, ext_announcable in [(False, False), (False, True),
                                                                   (True, False), (True, True)]}
                 for net in bgp_vrf.networks or []:
+                    # TODO(seba): implement ipv6
+                    if get_ip_version(net.network) != 4:
+                        continue
                     pl_name = self.gen_prefix_list_name(bgp_vrf.name, net.az_local, net.ext_announcable)
                     prefix_lists[pl_name].append({'ip-prefix': net.network, 'masklength-range': 'exact',
                                                   'config': {'ip-prefix': net.network, 'masklength-range': 'exact'}})
@@ -528,11 +534,17 @@ class EOSSwitch(SwitchBase):
             else:
                 # delete
                 for net in bgp_vrf.networks:
+                    # TODO(seba): implement ipv6
+                    if get_ip_version(net.network) != 4:
+                        continue
                     pl_name = self.gen_prefix_list_name(bgp_vrf.name, net.az_local, net.ext_announcable)
                     delete_req = EOSGNMIPaths.PREFIX_LIST_PREFIX.format(name=pl_name, prefix=net.network)
                     config_req.delete.append(delete_req)
 
                 for agg in bgp_vrf.aggregates:
+                    # TODO(seba): implement ipv6
+                    if get_ip_version(agg.network) != 4:
+                        continue
                     # NOTE: We're deleting regardless of route-map here
                     delete_req = EOSGNMIPaths.BGP_VRF_AGGREGATE_PREFIX.format(vrf=bgp_vrf.name,
                                                                               prefix=agg.network)
@@ -623,7 +635,7 @@ class EOSSwitch(SwitchBase):
                 delete_req = EOSGNMIPaths.EVPN_INSTANCE.format(vlan=bgp_vlan.vlan)
                 config_req.delete.append(delete_req)
 
-    def get_iface_secondary_ips(self):
+    def get_iface_secondary_ips_v4(self):
         ifaces = {}
 
         for entry in self.api.get(EOSGNMIPaths.IFACE_IPS_VIA_SYSDB, unpack=False)['notification']:
@@ -654,7 +666,7 @@ class EOSSwitch(SwitchBase):
             pc_details[pc['name']] = pc
 
         # secondary ips are only available via extra sysdb request
-        all_secondary_ips = self.get_iface_secondary_ips()
+        all_secondary_ips_v4 = self.get_iface_secondary_ips_v4()
 
         # vrfs are available in the network instances tree and need to be fetched seperately
         if with_vrfs:
@@ -674,10 +686,10 @@ class EOSSwitch(SwitchBase):
                                  .get('virtual-address', {})
                                  .get('config'))
                 if ip_config is not None:
-                    vlan_iface.primary_ip = f"{ip_config['ip']}/{ip_config['prefix-length']}"
+                    vlan_iface.primary_ip_v4 = f"{ip_config['ip']}/{ip_config['prefix-length']}"
 
-                if data['name'] in all_secondary_ips:
-                    vlan_iface.secondary_ips = list(all_secondary_ips[data['name']])
+                if data['name'] in all_secondary_ips_v4:
+                    vlan_iface.secondary_ips_v4 = list(all_secondary_ips_v4[data['name']])
 
                 vlan_ifaces.append(vlan_iface)
 
@@ -941,15 +953,15 @@ class EOSSwitch(SwitchBase):
                     if switch_vif.vlan in self.managed_vlans and switch_vif.vlan not in wanted_vlans:
                         config_req.delete.append(EOSGNMIPaths.IFACE.format(name=f"Vlan{switch_vif.vlan}"))
 
-            all_secondary_ips = self.get_iface_secondary_ips()
+            all_secondary_ips_v4 = self.get_iface_secondary_ips_v4()
             for viface in vlan_ifaces:
                 vifname = f"Vlan{viface.vlan}"
                 vconfig = {"name": vifname, "config": {"name": vifname, "type": "l3ipvlan"}}
 
                 # for the provided IPs we are always in replace mode
                 # NOTE: having secondary IPs, but no primary IP will always remove all secondary IPs
-                if viface.primary_ip:
-                    vip, plen = viface.primary_ip.split("/", 2)
+                if viface.primary_ip_v4:
+                    vip, plen = viface.primary_ip_v4.split("/", 2)
                     vconfig["arista-varp"] = {"virtual-address": {"config": {"ip": vip, "prefix-length": int(plen)}}}
                 else:
                     # remove address from interface
@@ -957,13 +969,13 @@ class EOSSwitch(SwitchBase):
 
                 # handle secondary ips
                 secondary_ip_cmds = []
-                if all_secondary_ips.get(vifname):
+                if all_secondary_ips_v4.get(vifname):
                     # clean unneeded secondary ips
-                    for ip in all_secondary_ips[vifname]:
-                        if ip not in (viface.secondary_ips or []):
+                    for ip in all_secondary_ips_v4[vifname]:
+                        if ip not in (viface.secondary_ips_v4 or []):
                             secondary_ip_cmds.append(("cli:", f"no ip address virtual {ip} secondary"))
 
-                for ip in viface.secondary_ips or []:
+                for ip in viface.secondary_ips_v4 or []:
                     secondary_ip_cmds.append(("cli:", f"ip address virtual {ip} secondary"))
 
                 if secondary_ip_cmds:

--- a/networking_ccloud/ml2/plugin.py
+++ b/networking_ccloud/ml2/plugin.py
@@ -24,7 +24,7 @@ from neutron_lib.plugins.ml2 import api as ml2_api
 from oslo_log import log as logging
 
 from networking_ccloud.common import constants as cc_const
-from networking_ccloud.common.helper import merge_segment_dicts
+from networking_ccloud.common.helper import get_ip_version, merge_segment_dicts
 from networking_ccloud.db.db_plugin import CCDbPlugin
 from networking_ccloud.ml2.agent.common import messages as agent_msg
 
@@ -129,23 +129,32 @@ class FabricPlugin(CCDbPlugin):
         net_gws = self.get_gateways_for_networks(context, network_ids, *args, **kwargs)
         result = {}
         for network_id, gws in net_gws.items():
-            result[network_id] = net = {'vrf': None, 'ips': []}
+            result[network_id] = net = {
+                'vrf': None,
+                'ips_v4': [],
+                'ips_v6': [],
+            }
             for gw_ip, ascope in gws:
                 vrf = self.drv_conf.global_config.get_vrf_name_for_address_scope(ascope)
                 if not vrf:
-                    LOG.warning("Address scope %s has no matching VRF for network %s", ascope, network_id)
+                    LOG.warning("Address scope %s has no matching VRF for network %s, skipping gateway %s",
+                                ascope, network_id, gw_ip)
                     continue
                 if net['vrf'] is None:
                     net['vrf'] = vrf
                 if net['vrf'] != vrf:
-                    # "this should never happen"
+                    # "this should never happen" (most likely scenario is on VRF mismatch between v4/v6)
                     LOG.error("Network address scope misconfiguration: Network %s has networks in two VRFs: (%s, %s), "
                               "therefore we are skipping l3 config of this network entirely",
                               network_id, result[network_id]['vrf'], vrf)
                     del result[network_id]
                     break
-                net['ips'].append(gw_ip)
-            if network_id in result and not net['ips']:
+
+                if get_ip_version(gw_ip) == 4:
+                    net['ips_v4'].append(gw_ip)
+                else:
+                    net['ips_v6'].append(gw_ip)
+            if network_id in result and not net['vrf']:
                 del result[network_id]
 
         return result
@@ -326,7 +335,7 @@ class FabricPlugin(CCDbPlugin):
                 vrf_aggregates.append((snp_cidr, bool(snp_az_local)))
             vrf['vrf_aggregates'] = vrf_aggregates
 
-            vrf['vrf_networks'].sort(key=lambda entry: ipaddress.ip_interface(entry[0]).ip)
-            vrf['vrf_aggregates'].sort(key=lambda entry: ipaddress.ip_interface(entry[0]).ip)
+            vrf['vrf_networks'].sort(key=lambda entry: int(ipaddress.ip_interface(entry[0]).ip))
+            vrf['vrf_aggregates'].sort(key=lambda entry: int(ipaddress.ip_interface(entry[0]).ip))
 
         return vrfs

--- a/networking_ccloud/tests/unit/extensions/test_extensions.py
+++ b/networking_ccloud/tests/unit/extensions/test_extensions.py
@@ -181,9 +181,10 @@ class TestNetworkExtension(test_segment.SegmentTestCase, base.PortBindingHelper,
 
         # config snippets that we expect to appear (used inside the tests as a base for comparison)
         self._infra_net_vifaces = [
-            agent_msg.VlanIface(vlan=23, vrf="PRIVATE-VRF", primary_ip="10.23.42.1/24",
-                                secondary_ips=["10.42.42.1/24"]),
-            agent_msg.VlanIface(vlan=42, vrf="ANOTHER-VRF", primary_ip="10.100.1.1/24", secondary_ips=[]),
+            agent_msg.VlanIface(vlan=23, vrf="PRIVATE-VRF", primary_ip_v4="10.23.42.1/24",
+                                secondary_ips_v4=["10.42.42.1/24"], secondary_ips_v6=[]),
+            agent_msg.VlanIface(vlan=42, vrf="ANOTHER-VRF", primary_ip_v4="10.100.1.1/24",
+                                secondary_ips_v4=[], secondary_ips_v6=[]),
         ]
         self._infra_net_bgp_vrfs = [
             agent_msg.BGPVRF(name='ANOTHER-VRF', networks=[
@@ -199,7 +200,8 @@ class TestNetworkExtension(test_segment.SegmentTestCase, base.PortBindingHelper,
             ]),
         ]
         self._seagull_vifaces = [
-            agent_msg.VlanIface(vlan=101, vrf="cc-seagull", primary_ip="1.1.1.1/24", secondary_ips=[]),
+            agent_msg.VlanIface(vlan=101, vrf="cc-seagull", primary_ip_v4="1.1.1.1/24",
+                                secondary_ips_v4=[], secondary_ips_v6=[]),
         ]
         self._seagull_bgpvrfs = [
             agent_msg.BGPVRF(name='cc-seagull', networks=[

--- a/networking_ccloud/tests/unit/ml2/agent/common/test_messages.py
+++ b/networking_ccloud/tests/unit/ml2/agent/common/test_messages.py
@@ -11,6 +11,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+import pydantic
 
 from networking_ccloud.common.config import config_driver
 from networking_ccloud.ml2.agent.common import messages as agent_msg
@@ -70,6 +71,36 @@ class TestSwitchConfigUpdate(base.TestCase):
         # format fixing
         self.assertEqual("65130.23:1234", agent_msg.validate_route_target("4268359703:1234"))
         self.assertEqual("123:123", agent_msg.validate_route_target("123:123"))
+
+    def test_vlan_iface_af_check_working(self):
+        svi = agent_msg.VlanIface(
+            vlan=1000,
+            primary_ip_v4="10.100.1.0/24", secondary_ips_v4=["10.100.2.0/24", "10.100.3.0/24"],
+            primary_ip_v6="fe80::1/64", secondary_ips_v6=["fe81::1/64", "fe82::1/64"],
+        )
+        expected = {
+            'vlan': 1000,
+            'vrf': None,
+            'primary_ip_v4': '10.100.1.0/24',
+            'primary_ip_v6': 'fe80::1/64',
+            'secondary_ips_v4': ['10.100.2.0/24', '10.100.3.0/24'],
+            'secondary_ips_v6': ['fe81::1/64', 'fe82::1/64'],
+        }
+        self.assertEqual(expected, svi.dict())
+
+    def test_vlan_iface_af_check_failing(self):
+        self.assertRaisesRegex(
+            pydantic.ValidationError, ".*fe80::1/128 is not a valid IPv4 address/prefix.*",
+            agent_msg.VlanIface, vlan=1000, primary_ip_v4="fe80::1/128")
+        self.assertRaisesRegex(
+            pydantic.ValidationError, ".*fe80::1/64 is not a valid IPv4 address/prefix.*",
+            agent_msg.VlanIface, vlan=1000, secondary_ips_v4=["10.100.1.1/24", "fe80::1/64"])
+        self.assertRaisesRegex(
+            pydantic.ValidationError, ".*10.100.1.1/24 is not a valid IPv6 address/prefix.*",
+            agent_msg.VlanIface, vlan=1000, primary_ip_v6="10.100.1.1/24")
+        self.assertRaisesRegex(
+            pydantic.ValidationError, ".*10.100.1.1/24 is not a valid IPv6 address/prefix.*",
+            agent_msg.VlanIface, vlan=1000, secondary_ips_v6=["10.100.1.1/24", "fe80::1/64"])
 
 
 class TestSwitchConfigUpdateList(base.TestCase):

--- a/networking_ccloud/tests/unit/ml2/agent/eos/test_switch.py
+++ b/networking_ccloud/tests/unit/ml2/agent/eos/test_switch.py
@@ -302,8 +302,8 @@ class TestEOSConfigUpdates(base.TestCase):
         cu.add_iface(iface2)
 
         # vlan iface + vrf
-        cu.add_vlan_iface(vlan=2337, vrf="CC-SEAGULL", primary_ip="1.1.1.1/24",
-                          secondary_ips=["2.2.2.2/24", "3.3.3.3/24"])
+        cu.add_vlan_iface(vlan=2337, vrf="CC-SEAGULL", primary_ip_v4="1.1.1.1/24",
+                          secondary_ips_v4=["2.2.2.2/24", "3.3.3.3/24"])
         vrf = cu.bgp.get_or_create_vrf("CC-SEAGULL")
         vrf.add_networks([
             messages.BGPVRFNetwork(network="4.4.4.0/24", az_local=False, ext_announcable=False),
@@ -460,8 +460,8 @@ class TestEOSConfigUpdates(base.TestCase):
         cu.add_iface(iface2)
 
         # vlan iface + vrf
-        cu.add_vlan_iface(vlan=2337, vrf="CC-SEAGULL", primary_ip="1.1.1.1/24",
-                          secondary_ips=["2.2.2.2/24", "3.3.3.3/24"])
+        cu.add_vlan_iface(vlan=2337, vrf="CC-SEAGULL", primary_ip_v4="1.1.1.1/24",
+                          secondary_ips_v4=["2.2.2.2/24", "3.3.3.3/24"])
         vrf = cu.bgp.get_or_create_vrf("CC-SEAGULL")
         vrf.add_networks([
             messages.BGPVRFNetwork(network="4.4.4.0/24", az_local=False, ext_announcable=False),
@@ -896,7 +896,7 @@ class TestEOSConfigUpdates(base.TestCase):
         }
 
         cu = messages.SwitchConfigUpdate(switch_name="seagull-sw1", operation=messages.OperationEnum.replace)
-        cu.add_vlan_iface(vlan=2337, primary_ip="1.1.1.1/24")
+        cu.add_vlan_iface(vlan=2337, primary_ip_v4="1.1.1.1/24")
 
         self.switch.apply_config_update(cu).result()
         self.switch._api.set.assert_called_with(**expected_config)
@@ -1235,8 +1235,8 @@ class TestEOSSwitch(base.TestCase):
         iface.add_vlan_translation(2000, 3001)
         cu.add_iface(iface)
 
-        cu.add_vlan_iface(vlan=2337, vrf="CC-SEAGULL", primary_ip="1.1.1.1/24",
-                          secondary_ips=["2.2.2.2/24", "3.3.3.3/24"])
+        cu.add_vlan_iface(vlan=2337, vrf="CC-SEAGULL", primary_ip_v4="1.1.1.1/24",
+                          secondary_ips_v4=["2.2.2.2/24", "3.3.3.3/24"])
         vrf = cu.bgp.get_or_create_vrf("CC-SEAGULL")
         vrf.add_networks([
             messages.BGPVRFNetwork(network="4.4.4.0/24", az_local=False, ext_announcable=False),

--- a/networking_ccloud/tests/unit/ml2/test_mech_driver.py
+++ b/networking_ccloud/tests/unit/ml2/test_mech_driver.py
@@ -125,7 +125,7 @@ class TestCCFabricMechanismDriver(CCFabricMechanismDriverTestBase):
 
         hostgroups = hg_seagull + hg_crow + hg_cat + hg_squirrel
 
-        extra_vrfs = [{"name": "cc-earth", "address_scopes": ["the-open-sea"], "number": 23}]
+        extra_vrfs = [{"name": "cc-earth", "address_scopes": ["the-open-sea", "the-dark-abyss"], "number": 23}]
         self.conf_drv = cfix.make_config(switchgroups=switchgroups, hostgroups=hostgroups, extra_vrfs=extra_vrfs)
         _override_driver_config(self.conf_drv)
 
@@ -141,6 +141,8 @@ class TestCCFabricMechanismDriver(CCFabricMechanismDriverTestBase):
         with db_api.CONTEXT_WRITER.using(ctx):
             self._address_scope = ascope_models.AddressScope(name="the-open-sea", ip_version=4)
             ctx.session.add(self._address_scope)
+            self._address_scope_v6 = ascope_models.AddressScope(name="the-dark-abyss", ip_version=6)
+            ctx.session.add(self._address_scope_v6)
 
     def test_bind_port_direct_level_0(self):
         with mock.patch.object(self.mech_driver, 'handle_binding_host_changed') as mock_bhc:
@@ -658,8 +660,8 @@ class TestCCFabricMechanismDriver(CCFabricMechanismDriverTestBase):
                             # check for vlan ids
                             vlan_id = swcfg.bgp.vlans[0].vlan
                             self.assertEqual([
-                                agent_msg.VlanIface(vlan=vlan_id, vrf="cc-earth", primary_ip="1.1.1.1/24",
-                                                    secondary_ips=[]),
+                                agent_msg.VlanIface(vlan=vlan_id, vrf="cc-earth", primary_ip_v4="1.1.1.1/24",
+                                                    secondary_ips_v4=[], secondary_ips_v6=[]),
                             ], swcfg.vlan_ifaces)
 
                             # check bgp config
@@ -676,6 +678,57 @@ class TestCCFabricMechanismDriver(CCFabricMechanismDriverTestBase):
                                     ],
                                 ),
                             ], swcfg.bgp.vrfs)
+
+    def test_bind_port_external_network_dualstack(self):
+        net_kwargs = {'arg_list': (extnet_api.EXTERNAL,), extnet_api.EXTERNAL: True, 'as_admin': True}
+        with self.network(**net_kwargs) as network, \
+                self.subnetpool(["1.1.0.0/16", "1.2.0.0/24"], address_scope_id=self._address_scope.id, name="foo",
+                                tenant_id="foo", admin=True) as snp_v4, \
+                self.subnetpool(["2001:db8::/32"], address_scope_id=self._address_scope_v6.id, name="bar",
+                                tenant_id="foo", admin=True) as snp_v6, \
+                self.subnet(network=network, cidr="1.1.1.0/24", gateway_ip="1.1.1.1",
+                            subnetpool_id=snp_v4['subnetpool']['id'], as_admin=True) as snv4_1, \
+                self.subnet(network=network, cidr="1.1.3.0/24", gateway_ip="1.1.3.1",
+                            subnetpool_id=snp_v4['subnetpool']['id'], as_admin=True), \
+                self.subnet(network=network, cidr="2001:db8:6775:6c6c::/64", gateway_ip="2001:db8:6775:6c6c::1",
+                            subnetpool_id=snp_v6['subnetpool']['id'], ip_version=6, as_admin=True), \
+                self.subnet(network=network, cidr="2001:db8:6269:7264::/64", gateway_ip="2001:db8:6269:7264::1",
+                            subnetpool_id=snp_v6['subnetpool']['id'], ip_version=6, as_admin=True), \
+                mock.patch.object(CCFabricSwitchAgentRPCClient, 'apply_config_update') as mock_acu:
+            context1 = self._test_bind_port(fake_host='nova-compute-seagull',
+                                            network=network, subnet=snv4_1)
+            context1.continue_binding.assert_called()
+            mock_acu.assert_called()
+            swcfgs = mock_acu.call_args[0][1]
+            for swcfg in swcfgs:
+                # check for vlan ids
+                vlan_id = swcfg.bgp.vlans[0].vlan
+                self.assertEqual([
+                    agent_msg.VlanIface(vlan=vlan_id, vrf="cc-earth",
+                                        primary_ip_v4="1.1.1.1/24", secondary_ips_v4=["1.1.3.1/24"],
+                                        primary_ip_v6="2001:db8:6269:7264::1/64",
+                                        secondary_ips_v6=["2001:db8:6775:6c6c::1/64"]),
+                ], swcfg.vlan_ifaces)
+
+                # check bgp config
+                self.assertEqual([
+                    agent_msg.BGPVRF(
+                        name="cc-earth",
+                        networks=[
+                            agent_msg.BGPVRFNetwork(network='1.1.1.0/24', az_local=False, ext_announcable=False),
+                            agent_msg.BGPVRFNetwork(network='1.1.3.0/24', az_local=False, ext_announcable=False),
+                            agent_msg.BGPVRFNetwork(network='2001:db8:6269:7264::/64',
+                                                    az_local=False, ext_announcable=False),
+                            agent_msg.BGPVRFNetwork(network='2001:db8:6775:6c6c::/64',
+                                                    az_local=False, ext_announcable=False),
+                        ],
+                        aggregates=[
+                            agent_msg.BGPVRFAggregate(network='1.1.0.0/16', az_local=False),
+                            agent_msg.BGPVRFAggregate(network='1.2.0.0/24', az_local=False),
+                            agent_msg.BGPVRFAggregate(network='2001:db8::/32', az_local=False),
+                        ],
+                    ),
+                ], swcfg.bgp.vrfs)
 
     def test_bind_port_external_network_with_ext_announcable(self):
         net_kwargs = {'arg_list': (extnet_api.EXTERNAL,), extnet_api.EXTERNAL: True, 'as_admin': True}
@@ -694,8 +747,8 @@ class TestCCFabricMechanismDriver(CCFabricMechanismDriverTestBase):
                             # check for vlan ids
                             vlan_id = swcfg.bgp.vlans[0].vlan
                             self.assertEqual([
-                                agent_msg.VlanIface(vlan=vlan_id, vrf="cc-earth", primary_ip="1.1.1.1/24",
-                                                    secondary_ips=[]),
+                                agent_msg.VlanIface(vlan=vlan_id, vrf="cc-earth", primary_ip_v4="1.1.1.1/24",
+                                                    secondary_ips_v4=[], secondary_ips_v6=[]),
                             ], swcfg.vlan_ifaces)
 
                             # check bgp config
@@ -735,8 +788,8 @@ class TestCCFabricMechanismDriver(CCFabricMechanismDriverTestBase):
                             # check for vlan ids
                             vlan_id = swcfg.bgp.vlans[0].vlan
                             self.assertEqual([
-                                agent_msg.VlanIface(vlan=vlan_id, vrf="cc-earth", primary_ip="1.1.1.1/24",
-                                                    secondary_ips=[]),
+                                agent_msg.VlanIface(vlan=vlan_id, vrf="cc-earth", primary_ip_v4="1.1.1.1/24",
+                                                    secondary_ips_v4=[], secondary_ips_v6=[]),
                             ], swcfg.vlan_ifaces)
 
                             # check bgp config
@@ -791,8 +844,8 @@ class TestCCFabricMechanismDriver(CCFabricMechanismDriverTestBase):
                                 # check for vlan ids
                                 vlan_id = swcfg.bgp.vlans[0].vlan
                                 self.assertEqual([
-                                    agent_msg.VlanIface(vlan=vlan_id, vrf="cc-earth", primary_ip="1.1.1.1/24",
-                                                        secondary_ips=[]),
+                                    agent_msg.VlanIface(vlan=vlan_id, vrf="cc-earth", primary_ip_v4="1.1.1.1/24",
+                                                        secondary_ips_v4=[], secondary_ips_v6=[]),
                                 ], swcfg.vlan_ifaces)
 
                                 # check bgp config


### PR DESCRIPTION
In the communication between the ml2 driver and switch agent we did not split up between ipv4 and ipv6 - all ips went into the same lists/attributes and it was up to the agent to split this. For BGP networks and aggregates this works fine, but for the interface primary ip the agent would need to pick a second primary ip from the address family not being the primary ip. To make this clearer we split up primary_ip and secondary_ips into a v4/v6 version and split the IPs in the ml2 driver part.

When sorting ip addresses from both address families we now compare their int value for a stable sorting, as we cannot compare v4 and v6 representations with each other. For gateways we sort the list of each gateway individually to get a stable list.

For general v6 compatibility we now also filter out v6 in the EOS agent for now, until we either require that feature or get a testbed for working on this.